### PR TITLE
Added missing translation for "Set progress" button

### DIFF
--- a/client/src/pages/Details.tsx
+++ b/client/src/pages/Details.tsx
@@ -643,7 +643,7 @@ const SetProgressButton: FunctionComponent<{
     <Modal
       openModal={(openModal) => (
         <div className="text-sm text-green-500 btn" onClick={() => openModal()}>
-          Set progress
+          <Trans>Set progress</Trans>
         </div>
       )}
     >


### PR DESCRIPTION
Added translation for the "Set progress" button.

After:
![image](https://user-images.githubusercontent.com/11770760/155231388-106c1be6-51a2-4e11-b8cd-d337f1653bd9.png)

Before:
![image](https://user-images.githubusercontent.com/11770760/155231426-127ee65f-6802-4a77-80f8-6ac2f5d2968a.png)
