### PR TITLE
fix: airtime off by 24 hours, #261

### DIFF
--- a/client/src/components/GridItem.tsx
+++ b/client/src/components/GridItem.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { t, Trans } from '@lingui/macro';
+import { parseISO } from 'date-fns';
 
 import { addToWatchlist, removeFromWatchlist } from 'src/api/details';
 import { BadgeRating } from 'src/components/StarRating';
@@ -146,7 +147,7 @@ export const GridItem: FunctionComponent<{
           <div className="flex justify-between text-gray-500 dark:text-gray-400">
             <span>
               {mediaItem.releaseDate &&
-                new Date(mediaItem.releaseDate).getFullYear()}
+                parseISO(mediaItem.releaseDate).getFullYear()}
             </span>
 
             <span>{mediaTypeString[mediaItem.mediaType]}</span>
@@ -174,13 +175,13 @@ export const GridItem: FunctionComponent<{
                 <>
                   {formatEpisodeNumber(mediaItem.upcomingEpisode)}{' '}
                   <RelativeTime
-                    to={new Date(mediaItem.upcomingEpisode.releaseDate)}
+                    to={parseISO(mediaItem.upcomingEpisode.releaseDate)}
                   />
                 </>
               )}
               {mediaItem.mediaType !== 'tv' && mediaItem.releaseDate && (
                 <Trans>
-                  Release <RelativeTime to={new Date(mediaItem.releaseDate)} />
+                  Release <RelativeTime to={parseISO(mediaItem.releaseDate)} />
                 </Trans>
               )}
             </div>
@@ -192,13 +193,13 @@ export const GridItem: FunctionComponent<{
                 <>
                   {formatEpisodeNumber(mediaItem.lastAiredEpisode)}{' '}
                   <RelativeTime
-                    to={new Date(mediaItem.lastAiredEpisode.releaseDate)}
+                    to={parseISO(mediaItem.lastAiredEpisode.releaseDate)}
                   />
                 </>
               )}
               {mediaItem.mediaType !== 'tv' && mediaItem.releaseDate && (
                 <Trans>
-                  Released <RelativeTime to={new Date(mediaItem.releaseDate)} />
+                  Released <RelativeTime to={parseISO(mediaItem.releaseDate)} />
                 </Trans>
               )}
             </div>

--- a/client/src/mediaItem.ts
+++ b/client/src/mediaItem.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { parseISO } from 'date-fns';
 
 import {
   MediaItemDetailsResponse,
@@ -37,7 +38,7 @@ export const hasBeenReleased = (
   mediaItem: TvEpisode | MediaItemDetailsResponse | MediaItemItemsResponse
 ) => {
   const releaseDate = mediaItem.releaseDate;
-  return releaseDate && new Date(releaseDate) <= new Date();
+  return releaseDate && parseISO(releaseDate) <= new Date();
 };
 
 export const useSelectedSeason = (mediaItem?: MediaItemDetailsResponse) => {

--- a/client/src/pages/Calendar.tsx
+++ b/client/src/pages/Calendar.tsx
@@ -6,6 +6,7 @@ import listPlugin from '@fullcalendar/list';
 import allLocales from '@fullcalendar/core/locales-all';
 import { Link } from 'react-router-dom';
 import { useLingui } from '@lingui/react';
+import { parseISO } from 'date-fns';
 
 import { MediaItemItemsResponse, MediaType, TvEpisode } from 'mediatracker-api';
 import { mediaTrackerApi } from 'src/api/api';
@@ -29,7 +30,7 @@ export const CalendarPage: FunctionComponent = () => {
       data?.episodes.map(
         (episode: TvEpisode & { tvShow: MediaItemItemsResponse }) => ({
           title: episode.tvShow.title,
-          date: new Date(episode.releaseDate),
+          date: parseISO(episode.releaseDate),
           allDay: true,
           backgroundColor: episodeColor(episode),
           borderColor: episodeColor(episode),
@@ -50,7 +51,7 @@ export const CalendarPage: FunctionComponent = () => {
     () =>
       data?.items.map((mediaItem) => ({
         title: mediaItem.title,
-        date: new Date(mediaItem.releaseDate),
+        date: parseISO(mediaItem.releaseDate),
         allDay: true,
         backgroundColor: eventColor(mediaItem.mediaType),
         borderColor: eventColor(mediaItem.mediaType),

--- a/client/src/pages/Details.tsx
+++ b/client/src/pages/Details.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import clsx from 'clsx';
-import { formatDuration, intervalToDuration } from 'date-fns';
+import { formatDuration, intervalToDuration, parseISO } from 'date-fns';
 import { Plural, plural, t, Trans } from '@lingui/macro';
 
 import {
@@ -268,7 +268,7 @@ export const DetailsPage: FunctionComponent = () => {
                 <Trans>Release date</Trans>:{' '}
               </span>
               <span>
-                {new Date(mediaItem.releaseDate).toLocaleDateString()}
+                {parseISO(mediaItem.releaseDate).toLocaleDateString()}
               </span>
             </div>
           )}
@@ -542,7 +542,7 @@ export const DetailsPage: FunctionComponent = () => {
             <Trans>Next episode</Trans>{' '}
             {mediaItem.upcomingEpisode.releaseDate && (
               <RelativeTime
-                to={new Date(mediaItem.upcomingEpisode.releaseDate)}
+                to={parseISO(mediaItem.upcomingEpisode.releaseDate)}
               />
             )}
             : {formatEpisodeNumber(mediaItem.upcomingEpisode)}{' '}

--- a/client/src/pages/Episodes.tsx
+++ b/client/src/pages/Episodes.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import clsx from 'clsx';
 import { Plural, t, Trans } from '@lingui/macro';
+import { parseISO } from 'date-fns';
 
 import { markAsUnseen, useDetails } from 'src/api/details';
 import { Modal } from 'src/components/Modal';
@@ -54,7 +55,7 @@ const EpisodeComponent: FunctionComponent<{
           {episode.releaseDate && (
             <>
               <div className="text-sm italic">
-                {new Date(episode.releaseDate).toLocaleDateString()}
+                {parseISO(episode.releaseDate).toLocaleDateString()}
               </div>
             </>
           )}
@@ -194,7 +195,7 @@ const SeasonComponent: FunctionComponent<{
       <div className="flex w-full">
         {season.episodes?.filter(
           (episode) =>
-            episode.releaseDate && new Date(episode.releaseDate) <= new Date()
+            episode.releaseDate && parseISO(episode.releaseDate) <= new Date()
         ).length > 0 && <BadgeRating mediaItem={mediaItem} season={season} />}
 
         <Modal
@@ -206,7 +207,7 @@ const SeasonComponent: FunctionComponent<{
                 season.episodes?.filter(
                   (episode) =>
                     episode.releaseDate &&
-                    new Date(episode.releaseDate) <= new Date()
+                    parseISO(episode.releaseDate) <= new Date()
                 ).length === 0 && 'opacity-0 pointer-events-none'
               )}
             >

--- a/server/src/controllers/seen.ts
+++ b/server/src/controllers/seen.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { parseISO } from 'date-fns';
 
 import { createExpressRoute } from 'typescript-routes-to-openapi-server';
 import { TvEpisodeFilters } from 'src/entity/tvepisode';
@@ -55,12 +56,12 @@ export class SeenController {
             id: episodeId,
           });
 
-          date = new Date(episode.releaseDate);
+          date = parseISO(episode.releaseDate);
         } else if (seasonId) {
           const season = await tvSeasonRepository.findOne({
             id: seasonId,
           });
-          date = new Date(season.releaseDate);
+          date = parseISO(season.releaseDate);
         } else {
           const mediaItem = await mediaItemRepository.findOne({
             id: mediaItemId,
@@ -69,7 +70,7 @@ export class SeenController {
             res.sendStatus(400);
             return;
           }
-          date = new Date(mediaItem.releaseDate);
+          date = parseISO(mediaItem.releaseDate);
         }
       }
     }
@@ -107,7 +108,7 @@ export class SeenController {
           episodeId: episode.id,
           date:
             lastSeenAt === 'release_date'
-              ? new Date(episode.releaseDate).getTime()
+              ? parseISO(episode.releaseDate).getTime()
               : date?.getTime() || null,
           duration:
             episode.runtime * 60 * 1000 || mediaItem.runtime * 60 * 1000,
@@ -158,7 +159,7 @@ export class SeenController {
                 episodeId: episode.id,
                 date:
                   lastSeenAt === 'release_date'
-                    ? new Date(episode.releaseDate).getTime()
+                    ? parseISO(episode.releaseDate).getTime()
                     : date?.getTime() || null,
                 duration:
                   episode.runtime * 60 * 1000 || mediaItem.runtime * 60 * 1000,
@@ -183,7 +184,7 @@ export class SeenController {
                   episodeId: episode.id,
                   date:
                     lastSeenAt === 'release_date'
-                      ? new Date(episode.releaseDate).getTime()
+                      ? parseISO(episode.releaseDate).getTime()
                       : date?.getTime() || null,
                   duration:
                     episode.runtime * 60 * 1000 ||

--- a/server/src/entity/mediaItem.ts
+++ b/server/src/entity/mediaItem.ts
@@ -1,3 +1,5 @@
+import { parseISO } from 'date-fns';
+
 import { UserRating } from 'src/entity/userRating';
 import { Seen } from 'src/entity/seen';
 import { TvEpisode } from 'src/entity/tvepisode';
@@ -186,7 +188,7 @@ export const seasonPosterPath = (
 export const mediaItemSlug = (mediaItem: MediaItemBase) => {
   if (mediaItem.releaseDate) {
     return toSlug(
-      `${mediaItem.title}-${new Date(mediaItem.releaseDate).getFullYear()}`
+      `${mediaItem.title}-${parseISO(mediaItem.releaseDate).getFullYear()}`
     );
   } else {
     return toSlug(mediaItem.title);

--- a/server/src/knex/queries/details.ts
+++ b/server/src/knex/queries/details.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { parseISO } from 'date-fns';
 
 import { MediaItemBase, MediaItemDetailsResponse } from 'src/entity/mediaItem';
 import { TvEpisode, TvEpisodeFilters } from 'src/entity/tvepisode';
@@ -155,13 +156,13 @@ export const getDetailsKnex = async (params: {
     .filter(TvEpisodeFilters.withReleaseDateEpisodes)
     .filter(TvEpisodeFilters.nonSpecialEpisodes)
     .filter(TvEpisodeFilters.unreleasedEpisodes)
-    .minBy((episode) => new Date(episode.releaseDate).getTime());
+    .minBy((episode) => parseISO(episode.releaseDate).getTime());
 
   const lastAiredEpisode = _(episodes)
     .filter(TvEpisodeFilters.withReleaseDateEpisodes)
     .filter(TvEpisodeFilters.nonSpecialEpisodes)
     .filter(TvEpisodeFilters.releasedEpisodes)
-    .maxBy((episode) => new Date(episode.releaseDate).getTime());
+    .maxBy((episode) => parseISO(episode.releaseDate).getTime());
 
   const unseenEpisodesCount = _(episodes)
     .filter(TvEpisodeFilters.nonSpecialEpisodes)

--- a/server/src/migrations/20220312002700_mediaItemSlug.ts
+++ b/server/src/migrations/20220312002700_mediaItemSlug.ts
@@ -1,3 +1,4 @@
+import { parseISO } from 'date-fns';
 import { Knex } from 'knex';
 import { randomSlugId, toSlug } from 'src/slug';
 
@@ -59,7 +60,7 @@ export async function up(knex: Knex): Promise<void> {
 
   for (const mediaItem of mediaItems) {
     const releaseYear = mediaItem.releaseDate
-      ? new Date(mediaItem.releaseDate).getFullYear()
+      ? parseISO(mediaItem.releaseDate).getFullYear()
       : undefined;
 
     const slug = toSlug(

--- a/server/src/sendNotifications.ts
+++ b/server/src/sendNotifications.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import chalk from 'chalk';
-import { addHours, subHours } from 'date-fns';
+import { addHours, parseISO, subHours } from 'date-fns';
 import { plural, t } from '@lingui/macro';
 
 import { MediaItemBase } from 'src/entity/mediaItem';
@@ -36,7 +36,7 @@ const notificationForFutureItems = async () => {
       async () =>
         (await checkIfNotificationHasBeenSent(mediaItem)) &&
         (await sendNotificationForMediaItem(mediaItem)),
-      new Date(mediaItem.releaseDate)
+      parseISO(mediaItem.releaseDate)
     );
   }
 };
@@ -82,7 +82,7 @@ const notificationForFutureEpisodes = async () => {
               groupedByTvShow.filter(checkIfNotificationHasBeenSent)
             )
           ),
-        new Date(groupedByTvShow[0].releaseDate)
+        parseISO(groupedByTvShow[0].releaseDate)
       );
     }
   }

--- a/server/src/updateMetadata.ts
+++ b/server/src/updateMetadata.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import chalk from 'chalk';
 import { plural, t } from '@lingui/macro';
+import { parseISO } from 'date-fns';
 
 import {
   MediaItemBase,
@@ -186,7 +187,7 @@ const sendNotifications = async (
 
   if (
     newMediaItem.releaseDate !== oldMediaItem.releaseDate &&
-    new Date(newMediaItem.releaseDate) > new Date()
+    parseISO(newMediaItem.releaseDate) > new Date()
   ) {
     await send({
       message: t`Release date changed for ${newMediaItem.title}: "${newMediaItem.releaseDate}"`,
@@ -231,11 +232,11 @@ const sendNotifications = async (
         ];
 
       if (newSeason.releaseDate) {
-        if (new Date(newSeason.releaseDate) > new Date())
+        if (parseISO(newSeason.releaseDate) > new Date())
           await send({
             message: t`New season of ${
               newMediaItem.title
-            } will be released at ${new Date(
+            } will be released at ${parseISO(
               newSeason.releaseDate
             ).toLocaleDateString()}`,
             filter: (user) => user.sendNotificationWhenNumberOfSeasonsChanges,
@@ -255,12 +256,12 @@ const sendNotifications = async (
       if (
         oldMediaItemLastSeason.releaseDate !==
           newMediaItemLastSeason.releaseDate &&
-        new Date(newMediaItemLastSeason.releaseDate) > new Date()
+        parseISO(newMediaItemLastSeason.releaseDate) > new Date()
       ) {
         await send({
           message: t`Season ${newMediaItemLastSeason.seasonNumber} of ${
             newMediaItem.title
-          } will be released at ${new Date(
+          } will be released at ${parseISO(
             newMediaItemLastSeason.releaseDate
           ).toLocaleDateString()}`,
           filter: (user) => user.sendNotificationWhenNumberOfSeasonsChanges,
@@ -360,8 +361,8 @@ const shouldUpdate = (mediaItem: MediaItemBase) => {
   if (
     mediaItem.mediaType !== 'tv' &&
     mediaItem.releaseDate &&
-    new Date(mediaItem.releaseDate) < new Date() &&
-    new Date(mediaItem.releaseDate) < new Date(mediaItem.lastTimeUpdated)
+    parseISO(mediaItem.releaseDate) < new Date() &&
+    parseISO(mediaItem.releaseDate) < new Date(mediaItem.lastTimeUpdated)
   ) {
     return (
       timePassed >=


### PR DESCRIPTION
Release date without time zone are parsed assuming UTC time zone, resulting in an offset by 24 hours in some time zones, see [here](https://stackoverflow.com/a/7556634). Use instead [date-fns/parseISO](https://date-fns.org/v2.28.0/docs/parseISO)