### PR TITLE
use current MediaTracker version for openapi generation

### DIFF
--- a/server/scripts/generateRoutes.ts
+++ b/server/scripts/generateRoutes.ts
@@ -1,10 +1,11 @@
 import { typescriptRoutesToOpenApi } from 'typescript-routes-to-openapi';
+import { version } from '../package.json';
 
 typescriptRoutesToOpenApi({
   openapi: {
     info: {
       title: 'MediaTracker',
-      version: '0.0.1',
+      version: version,
       license: {
         name: 'MIT',
         url: 'https://opensource.org/licenses/MIT',


### PR DESCRIPTION
`openapi.json` documentation has fixed, hardcoded version `0.0.1`
https://github.com/bonukai/MediaTracker/blob/b70148378d9ce346464e6e2072f3f876d6ec04a2/server/openapi.json#L5

Use version from package.json instead