### PR TITLE
fix: remove single seen entry on the seen page

### DIFF
--- a/client/src/api/details.ts
+++ b/client/src/api/details.ts
@@ -253,12 +253,17 @@ export const markAsUnseen = async (args: {
   mediaItem: MediaItemItemsResponse;
   season?: TvSeason;
   episode?: TvEpisode;
+  seenId?: number;
 }) => {
-  await mediaTrackerApi.seen.delete({
-    mediaItemId: args.mediaItem.id,
-    seasonId: args.season?.id,
-    episodeId: args.episode?.id,
-  });
+  if (args.seenId) {
+    await mediaTrackerApi.seen.deleteById(args.seenId);
+  } else {
+    await mediaTrackerApi.seen.delete({
+      mediaItemId: args.mediaItem.id,
+      seasonId: args.season?.id,
+      episodeId: args.episode?.id,
+    });
+  }
 
   await updateMediaItem(args.mediaItem);
   queryClient.invalidateQueries(['items']);

--- a/client/src/components/AddAndRemoveFromSeenHistoryButton.tsx
+++ b/client/src/components/AddAndRemoveFromSeenHistoryButton.tsx
@@ -81,21 +81,26 @@ export const RemoveFromSeenHistoryButton: FunctionComponent<{
   mediaItem: MediaItemDetailsResponse;
   season?: TvSeason;
   episode?: TvEpisode;
+  seenId?: number;
 }> = (props) => {
-  const { mediaItem, season, episode } = props;
+  const { mediaItem, season, episode, seenId } = props;
 
   const seasonEpisodesIdSet = new Set(
     season?.episodes?.map((episode) => episode.id)
   );
 
-  const count = episode
-    ? mediaItem.seenHistory?.filter((entry) => entry.episodeId === episode?.id)
-        .length
-    : season
-    ? mediaItem.seenHistory?.filter((entry) =>
-        seasonEpisodesIdSet.has(entry.episodeId)
-      ).length
-    : mediaItem.seenHistory?.length;
+  const count =
+    seenId !== undefined
+      ? 1
+      : episode
+      ? mediaItem.seenHistory?.filter(
+          (entry) => entry.episodeId === episode?.id
+        ).length
+      : season
+      ? mediaItem.seenHistory?.filter((entry) =>
+          seasonEpisodesIdSet.has(entry.episodeId)
+        ).length
+      : mediaItem.seenHistory?.length;
 
   return (
     <div
@@ -111,6 +116,7 @@ export const RemoveFromSeenHistoryButton: FunctionComponent<{
           mediaItem: mediaItem,
           season: season,
           episode: episode,
+          seenId: seenId,
         })
       }
     >

--- a/client/src/pages/SeenHistory.tsx
+++ b/client/src/pages/SeenHistory.tsx
@@ -130,6 +130,7 @@ export const SeenHistoryPage: FunctionComponent = () => {
                           episodesMap[seenEntry.episodeId]) ||
                         undefined
                       }
+                      seenId={seenEntry.id}
                     />
                   </div>
                 </li>


### PR DESCRIPTION
Button for removing seen entry on seen page removes all entries, see https://github.com/bonukai/MediaTracker/issues/266#issuecomment-1120103506.