### PR TITLE
fix duplicate PUID and PGID in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN npm install --production
 FROM node:16-alpine3.16 as node
 FROM alpine:3.16
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl shadow
 RUN if [[ $(uname -m) == armv7l ]]; then apk add --no-cache vips; fi
 
 WORKDIR /storage
@@ -55,6 +55,9 @@ EXPOSE $PORT
 
 ENV PUID=1000
 ENV PGID=1000
+
+RUN groupadd --non-unique --gid 1000 abc
+RUN useradd --non-unique --create-home --uid 1000 --gid abc abc
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl ${HOSTNAME}:${PORT}
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,17 @@
 #!/bin/sh
 
-addgroup -g $PGID abc
-adduser -D -u $PUID -G abc abc
+if ! [ "$PGID" -eq "$(id -g abc)" ]; then
+    groupmod --non-unique --gid "$PGID" abc
+fi
+
+if ! [ "$PUID" -eq "$(id -u abc)" ]; then
+    usermod --non-unique --uid "$PUID" abc
+fi
+
+echo 
+echo PUID: $(id -u abc)
+echo PGID: $(id -g abc)
+echo 
 
 chown -R abc:abc /storage
 chown -R abc:abc /assets


### PR DESCRIPTION
Use [shadow](https://pkgs.alpinelinux.org/package/edge/community/x86/shadow) to manage user in Docker container. `useradd` in `alpine` cannot create non unique PUID, so not all PUID can be set