### PR TITLE
remove "slug" from mediaItem

### DIFF
--- a/server/__tests__/__utils__/data.ts
+++ b/server/__tests__/__utils__/data.ts
@@ -14,7 +14,6 @@ export class Data {
     mediaType: 'tv',
     source: 'tmdb',
     title: 'title',
-    slug: 'title',
     poster: 'posterUrl',
     backdrop: 'backdropUrl',
     releaseDate: '2002-05-07',
@@ -75,7 +74,6 @@ export class Data {
     mediaType: 'movie',
     source: 'tmdb',
     title: 'movie',
-    slug: 'movie',
     poster: 'posterUrl',
     backdrop: 'backdropUrl',
     releaseDate: '2001-04-12',
@@ -89,7 +87,6 @@ export class Data {
     mediaType: 'video_game',
     source: 'imdb',
     title: 'video_game',
-    slug: 'video_game',
     poster: 'posterUrl',
     backdrop: 'backdropUrl',
   };
@@ -100,7 +97,6 @@ export class Data {
     mediaType: 'book',
     source: 'openlibrary',
     title: 'book',
-    slug: 'book',
     poster: 'posterUrl',
     backdrop: 'backdropUrl',
   };

--- a/server/__tests__/controllers/import/trakttvController.test.ts
+++ b/server/__tests__/controllers/import/trakttvController.test.ts
@@ -82,7 +82,6 @@ describe('TraktTv import', () => {
                   title: Data.movie.title,
                   year: parseISO(Data.movie.releaseDate).getFullYear(),
                   ids: {
-                    slug: Data.movie.slug,
                     tmdb: Data.movie.tmdbId,
                   },
                 },
@@ -96,7 +95,6 @@ describe('TraktTv import', () => {
                   title: Data.tvShow.title,
                   year: parseISO(Data.tvShow.releaseDate).getFullYear(),
                   ids: {
-                    slug: Data.tvShow.slug,
                     tmdb: Data.tvShow.tmdbId,
                   },
                 },
@@ -110,7 +108,6 @@ describe('TraktTv import', () => {
                   title: Data.tvShow.title,
                   year: parseISO(Data.tvShow.releaseDate).getFullYear(),
                   ids: {
-                    slug: Data.tvShow.slug,
                     tmdb: Data.tvShow.tmdbId,
                   },
                 },
@@ -131,7 +128,6 @@ describe('TraktTv import', () => {
                   title: Data.tvShow.title,
                   year: parseISO(Data.tvShow.releaseDate).getFullYear(),
                   ids: {
-                    slug: Data.tvShow.slug,
                     tmdb: Data.tvShow.tmdbId,
                   },
                 },
@@ -159,7 +155,6 @@ describe('TraktTv import', () => {
                     title: Data.movie.title,
                     year: parseISO(Data.movie.releaseDate).getFullYear(),
                     ids: {
-                      slug: Data.movie.slug,
                       tmdb: Data.movie.tmdbId,
                     },
                   },
@@ -183,7 +178,6 @@ describe('TraktTv import', () => {
                     title: Data.tvShow.title,
                     year: parseISO(Data.tvShow.releaseDate).getFullYear(),
                     ids: {
-                      slug: Data.tvShow.slug,
                       tmdb: Data.tvShow.tmdbId,
                     },
                   },
@@ -215,7 +209,6 @@ describe('TraktTv import', () => {
                   title: Data.movie.title,
                   year: parseISO(Data.movie.releaseDate).getFullYear(),
                   ids: {
-                    slug: Data.movie.slug,
                     tmdb: Data.movie.tmdbId,
                   },
                 },
@@ -228,7 +221,6 @@ describe('TraktTv import', () => {
                   title: Data.tvShow.title,
                   year: parseISO(Data.tvShow.releaseDate).getFullYear(),
                   ids: {
-                    slug: Data.tvShow.slug,
                     tmdb: Data.tvShow.tmdbId,
                   },
                 },
@@ -241,7 +233,6 @@ describe('TraktTv import', () => {
                   title: Data.tvShow.title,
                   year: parseISO(Data.tvShow.releaseDate).getFullYear(),
                   ids: {
-                    slug: Data.tvShow.slug,
                     tmdb: Data.tvShow.tmdbId,
                   },
                 },
@@ -261,7 +252,6 @@ describe('TraktTv import', () => {
                   title: Data.tvShow.title,
                   year: parseISO(Data.tvShow.releaseDate).getFullYear(),
                   ids: {
-                    slug: Data.tvShow.slug,
                     tmdb: Data.tvShow.tmdbId,
                   },
                 },

--- a/server/__tests__/migrations/foreignKeys.test.ts
+++ b/server/__tests__/migrations/foreignKeys.test.ts
@@ -4,7 +4,6 @@ import { clearDatabase, runMigrations } from '__tests__/__utils__/utils';
 const mediaItem = {
   id: 1,
   title: 'title',
-  slug: 'title',
   source: 'user',
 };
 

--- a/server/__tests__/migrations/migrations.test.ts
+++ b/server/__tests__/migrations/migrations.test.ts
@@ -9,9 +9,7 @@ import { MediaItemBase } from 'src/entity/mediaItem';
 import { Database } from 'src/dbconfig';
 import { randomSlugId, toSlug } from 'src/slug';
 import { nanoid } from 'nanoid';
-import { listRepository } from 'src/repository/list';
 import { ListSortBy } from 'src/entity/list';
-import { listItemRepository } from 'src/repository/listItemRepository';
 
 describe('migrations', () => {
   beforeAll(async () => {
@@ -1689,6 +1687,22 @@ describe('migrations', () => {
         (await Database.knex('configuration').first()).configurationJson
       )
     );
+  });
+
+  test('20230514000000_dropMediaItemSlug', async () => {
+    await Database.knex.migrate.up({
+      name: `20230514000000_dropMediaItemSlug.${Config.MIGRATIONS_EXTENSION}`,
+      directory: Config.MIGRATIONS_DIRECTORY,
+    });
+
+    await Database.knex.migrate.down({
+      directory: Config.MIGRATIONS_DIRECTORY,
+    });
+
+    await Database.knex.migrate.up({
+      name: `20230514000000_dropMediaItemSlug.${Config.MIGRATIONS_EXTENSION}`,
+      directory: Config.MIGRATIONS_DIRECTORY,
+    });
   });
 
   afterAll(clearDatabase);

--- a/server/__tests__/repository/mediaItem/getItems/episodes.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/episodes.test.ts
@@ -21,7 +21,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title',
-    slug: 'title',
     seasons: [
       {
         id: 1,

--- a/server/__tests__/repository/mediaItem/getItems/firstUnwatchedEpisode.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/firstUnwatchedEpisode.test.ts
@@ -84,7 +84,6 @@ const mediaItem: MediaItemBaseWithSeasons = {
   mediaType: 'tv',
   source: 'user',
   title: 'title',
-  slug: 'title',
   seasons: [
     {
       id: 1,

--- a/server/__tests__/repository/mediaItem/getItems/getItems.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/getItems.test.ts
@@ -11,7 +11,6 @@ const mediaItem: MediaItemBase = {
   mediaType: 'tv',
   source: 'user',
   title: 'title',
-  slug: 'title',
 };
 
 const user: User = {

--- a/server/__tests__/repository/mediaItem/getItems/lastAiredEpisode.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/lastAiredEpisode.test.ts
@@ -32,7 +32,6 @@ const mediaItem: MediaItemBaseWithSeasons = {
   mediaType: 'tv',
   source: 'user',
   title: 'title',
-  slug: 'title',
 };
 
 const seasons: TvSeason[] = [

--- a/server/__tests__/repository/mediaItem/getItems/lastSeen.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/lastSeen.test.ts
@@ -80,7 +80,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title',
-    slug: 'title',
     seasons: [
       {
         id: 1,
@@ -136,7 +135,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title2',
-    slug: 'title2',
   },
   {
     id: 3,
@@ -144,7 +142,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'movie',
     source: 'user',
     title: 'title3',
-    slug: 'title3',
   },
   {
     id: 4,
@@ -152,7 +149,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title4',
-    slug: 'title4',
     seasons: [
       {
         id: 3,
@@ -189,7 +185,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title5',
-    slug: 'title5',
     seasons: [
       {
         id: 4,

--- a/server/__tests__/repository/mediaItem/getItems/onWatchlist.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/onWatchlist.test.ts
@@ -53,7 +53,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title',
-    slug: 'title',
     seasons: [
       {
         id: 1,
@@ -109,7 +108,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title2',
-    slug: 'title2',
   },
   {
     id: 3,
@@ -117,7 +115,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'movie',
     source: 'user',
     title: 'title3',
-    slug: 'title3',
   },
   {
     id: 4,
@@ -125,7 +122,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title4',
-    slug: 'title4',
     seasons: [
       {
         id: 3,
@@ -162,7 +158,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title5',
-    slug: 'title5',
     seasons: [
       {
         id: 4,

--- a/server/__tests__/repository/mediaItem/getItems/progress.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/progress.test.ts
@@ -31,7 +31,6 @@ const mediaItem: MediaItemBase = {
   mediaType: 'book',
   source: 'user',
   title: 'title',
-  slug: 'title',
 };
 
 const date = new Date().getTime();

--- a/server/__tests__/repository/mediaItem/getItems/properties.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/properties.test.ts
@@ -23,7 +23,6 @@ const mediaItem: MediaItemBase = {
   source: 'user',
   status: 'status',
   title: 'title',
-  slug: 'title-2021',
   tmdbId: 4351,
   tmdbRating: 9.1,
   tvmazeId: 123845,

--- a/server/__tests__/repository/mediaItem/getItems/seen.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/seen.test.ts
@@ -79,7 +79,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title',
-    slug: 'title',
     seasons: [
       {
         id: 1,
@@ -135,7 +134,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title2',
-    slug: 'title2',
   },
   {
     id: 3,
@@ -143,7 +141,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'movie',
     source: 'user',
     title: 'title3',
-    slug: 'title3',
   },
   {
     id: 4,
@@ -151,7 +148,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title4',
-    slug: 'title4',
     seasons: [
       {
         id: 3,
@@ -188,7 +184,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title5',
-    slug: 'title5',
     seasons: [
       {
         id: 4,
@@ -223,7 +218,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'movie',
     source: 'user',
     title: 'title6',
-    slug: 'title6',
   },
 ];
 

--- a/server/__tests__/repository/mediaItem/getItems/seenHistory.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/seenHistory.test.ts
@@ -83,7 +83,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title',
-    slug: 'title',
     seasons: [
       {
         id: 1,
@@ -139,7 +138,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title2',
-    slug: 'title2',
   },
   {
     id: 3,
@@ -147,7 +145,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'movie',
     source: 'user',
     title: 'title3',
-    slug: 'title3',
   },
   {
     id: 4,
@@ -155,7 +152,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title4',
-    slug: 'title4',
     seasons: [
       {
         id: 3,
@@ -192,7 +188,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title5',
-    slug: 'title5',
     seasons: [
       {
         id: 4,

--- a/server/__tests__/repository/mediaItem/getItems/unseenEpisodesCount.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/unseenEpisodesCount.test.ts
@@ -82,7 +82,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title',
-    slug: 'title',
     seasons: [
       {
         id: 1,
@@ -138,7 +137,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title2',
-    slug: 'title2',
   },
   {
     id: 3,
@@ -146,7 +144,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'movie',
     source: 'user',
     title: 'title3',
-    slug: 'title3',
   },
   {
     id: 4,
@@ -154,7 +151,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title4',
-    slug: 'title4',
     seasons: [
       {
         id: 3,
@@ -191,7 +187,6 @@ const mediaItem: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title5',
-    slug: 'title5',
     seasons: [
       {
         id: 4,

--- a/server/__tests__/repository/mediaItem/getItems/upcomingEpisode.test.ts
+++ b/server/__tests__/repository/mediaItem/getItems/upcomingEpisode.test.ts
@@ -32,7 +32,6 @@ const mediaItems: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title',
-    slug: 'title',
     seasons: [
       {
         id: 1,
@@ -85,7 +84,6 @@ const mediaItems: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title2',
-    slug: 'title2',
     seasons: [
       {
         id: 3,
@@ -122,7 +120,6 @@ const mediaItems: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title3',
-    slug: 'title3',
     seasons: [
       {
         id: 4,
@@ -140,7 +137,6 @@ const mediaItems: MediaItemBaseWithSeasons[] = [
     mediaType: 'movie',
     source: 'user',
     title: 'title4',
-    slug: 'title4',
   },
   {
     id: 5,
@@ -148,7 +144,6 @@ const mediaItems: MediaItemBaseWithSeasons[] = [
     mediaType: 'video_game',
     source: 'user',
     title: 'title5',
-    slug: 'title5',
   },
   {
     id: 6,
@@ -156,7 +151,6 @@ const mediaItems: MediaItemBaseWithSeasons[] = [
     mediaType: 'book',
     source: 'user',
     title: 'title6',
-    slug: 'title6',
   },
   {
     id: 7,
@@ -164,7 +158,6 @@ const mediaItems: MediaItemBaseWithSeasons[] = [
     mediaType: 'tv',
     source: 'user',
     title: 'title7',
-    slug: 'title7',
     seasons: [
       {
         id: 5,

--- a/server/__tests__/repository/mediaItem/itemsToNotify/__utils__/setup.ts
+++ b/server/__tests__/repository/mediaItem/itemsToNotify/__utils__/setup.ts
@@ -6,7 +6,6 @@ const mediaItem = {
   mediaType: 'movie',
   source: 'tmdb',
   title: 'movie',
-  slug: 'movie',
   releaseDate: '2022-07-01',
 };
 
@@ -16,7 +15,6 @@ const mediaItem2 = {
   mediaType: 'movie',
   source: 'tmdb',
   title: 'movie2',
-  slug: 'movie2',
   releaseDate: '2022-08-01T00:00:00.000Z',
 };
 
@@ -26,7 +24,6 @@ const mediaItem3 = {
   mediaType: 'movie',
   source: 'tmdb',
   title: 'movie3',
-  slug: 'movie3',
   releaseDate: '2022-08-01',
 };
 
@@ -36,7 +33,6 @@ const mediaItem4 = {
   mediaType: 'movie',
   source: 'tmdb',
   title: 'movie4',
-  slug: 'movie4',
   releaseDate: '2022-08-01',
 };
 

--- a/server/__tests__/repository/mediaItem/itemsToPossiblyUpdate.test.ts
+++ b/server/__tests__/repository/mediaItem/itemsToPossiblyUpdate.test.ts
@@ -71,7 +71,6 @@ describe('itemsToPossiblyUpdate', () => {
       mediaType: 'movie',
       source: 'user',
       title: 'UserMovie',
-      slug: 'usermovie',
       poster: 'posterUrl',
       backdrop: 'backdropUrl',
       releaseDate: '2001-04-12',

--- a/server/__tests__/repository/mediaItem/mediaItem.test.ts
+++ b/server/__tests__/repository/mediaItem/mediaItem.test.ts
@@ -51,7 +51,6 @@ describe('mediaItemRepository', () => {
   test('create without id', async () => {
     const mediaItem: MediaItemBaseWithSeasons = {
       title: 'mediaItem123',
-      slug: 'mediaitem123',
       mediaType: 'tv',
       source: 'user',
       poster: 'poster',
@@ -172,7 +171,6 @@ describe('mediaItemRepository', () => {
     const mediaItem: MediaItemBaseWithSeasons = {
       id: 123,
       title: 'title111',
-      slug: 'title111',
       source: 'user',
       mediaType: 'tv',
       seasons: [
@@ -462,7 +460,6 @@ const mediaItem: MediaItemBaseWithSeasons = {
   mediaType: 'tv',
   source: 'user',
   title: 'title2',
-  slug: 'title2',
   audibleId: null,
   authors: null,
   backdrop: 'backdrop',
@@ -600,7 +597,6 @@ const updatedMediaItem = {
   overview: 'new overview',
   lastTimeUpdated: new Date().getTime(),
   title: 'new title',
-  slug: 'new-title-2000',
   audibleId: 'audibleId',
   authors: ['author', 'author 2'],
   backdrop: 'backdrop',

--- a/server/__tests__/repository/mediaItem/unlockLockedMediaItems.test.ts
+++ b/server/__tests__/repository/mediaItem/unlockLockedMediaItems.test.ts
@@ -9,7 +9,6 @@ const mediaItems: MediaItemBase[] = [
   {
     id: 0,
     title: 'title 0',
-    slug: 'title-0',
     mediaType: 'movie',
     source: 'user',
     lockedAt: new Date(2000, 10, 2).getTime(),
@@ -17,7 +16,6 @@ const mediaItems: MediaItemBase[] = [
   {
     id: 1,
     title: 'title 1',
-    slug: 'title-1',
     mediaType: 'movie',
     source: 'user',
     lockedAt: null,
@@ -25,7 +23,6 @@ const mediaItems: MediaItemBase[] = [
   {
     id: 2,
     title: 'title 2',
-    slug: 'title-2',
     mediaType: 'movie',
     source: 'user',
     lockedAt: new Date().getTime() - 23 * 60 * 60 * 1000,
@@ -33,7 +30,6 @@ const mediaItems: MediaItemBase[] = [
   {
     id: 3,
     title: 'title 3',
-    slug: 'title-3',
     mediaType: 'movie',
     source: 'user',
     lockedAt: new Date().getTime(),

--- a/server/__tests__/statisticsSummary.test.ts
+++ b/server/__tests__/statisticsSummary.test.ts
@@ -9,7 +9,6 @@ const tvShow = {
   mediaType: 'tv',
   source: 'user',
   title: 'title',
-  slug: 'title',
   runtime: 40,
 };
 
@@ -53,7 +52,6 @@ const movie = {
   mediaType: 'movie',
   source: 'user',
   title: 'title2',
-  slug: 'title2',
   runtime: 120,
 };
 
@@ -63,7 +61,6 @@ const book = {
   mediaType: 'book',
   source: 'user',
   title: 'title3',
-  slug: 'title3',
   numberOfPages: 123,
 };
 
@@ -73,7 +70,6 @@ const audiobook = {
   mediaType: 'audiobook',
   source: 'user',
   title: 'title4',
-  slug: 'title4',
   runtime: 999,
 };
 
@@ -83,7 +79,6 @@ const videoGame = {
   mediaType: 'video_game',
   source: 'user',
   title: 'title5',
-  slug: 'title5',
 };
 
 const user = {

--- a/server/__tests__/updateMediaItem.test.ts
+++ b/server/__tests__/updateMediaItem.test.ts
@@ -17,7 +17,6 @@ const tvShow: MediaItemBase = {
   mediaType: 'tv',
   source: 'user',
   title: 'title',
-  slug: 'title',
   runtime: 40,
 };
 
@@ -82,7 +81,6 @@ const movie = {
   mediaType: 'movie',
   source: 'user',
   title: 'title2',
-  slug: 'title2',
   runtime: 120,
 };
 

--- a/server/__tests__/utils/updateAsset.test.ts
+++ b/server/__tests__/utils/updateAsset.test.ts
@@ -9,7 +9,6 @@ import { Database } from 'src/dbconfig';
 const mediaItem = {
   id: 1,
   title: 'title',
-  slug: 'title',
   source: 'user',
 };
 

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2495,9 +2495,6 @@
                 "releaseDate": {
                   "type": "string"
                 },
-                "slug": {
-                  "type": "string"
-                },
                 "mediaType": {
                   "$ref": "#/components/schemas/MediaType"
                 },
@@ -2510,7 +2507,6 @@
                 "id",
                 "mediaType",
                 "releaseDate",
-                "slug",
                 "title"
               ]
             },
@@ -2901,10 +2897,6 @@
                     "$ref": "#/components/schemas/AudibleCountryCode"
                   }
                 ],
-                "nullable": true
-              },
-              "slug": {
-                "type": "string",
                 "nullable": true
               },
               "seasons": {
@@ -3455,10 +3447,6 @@
                   }
                 ],
                 "nullable": true
-              },
-              "slug": {
-                "type": "string",
-                "nullable": true
               }
             },
             "required": [
@@ -3834,14 +3822,10 @@
                   },
                   "username": {
                     "type": "string"
-                  },
-                  "slug": {
-                    "type": "string"
                   }
                 },
                 "required": [
                   "id",
-                  "slug",
                   "username"
                 ]
               }

--- a/server/src/controllers/calendar.ts
+++ b/server/src/controllers/calendar.ts
@@ -49,7 +49,6 @@ export type GetCalendarItemsResponse = {
     id: number;
     title: string;
     releaseDate: string;
-    slug: string;
     mediaType: MediaType;
     seen?: boolean;
   };
@@ -88,7 +87,6 @@ export const getCalendarItems = async (args: {
       'mediaItem.releaseDate': 'mediaItem.releaseDate',
       'mediaItem.runtime': 'mediaItem.runtime',
       'mediaItem.seen': 'mediaItemSeen.mediaItemId',
-      'mediaItem.slug': 'mediaItem.slug',
       'mediaItem.title': 'mediaItem.title',
       'mediaItemEpisode.episodeNumber': 'mediaItemEpisode.episodeNumber',
       'mediaItemEpisode.id': 'mediaItemEpisode.id',
@@ -169,7 +167,6 @@ export const getCalendarItems = async (args: {
       id: row['listItem.mediaItemId'],
       title: row['mediaItem.title'],
       releaseDate: row['mediaItem.releaseDate'],
-      slug: row['mediaItem.slug'],
       mediaType: row['mediaItem.mediaType'],
       seen: row['mediaItem.seen'] != undefined,
     },

--- a/server/src/controllers/import/traktTv.ts
+++ b/server/src/controllers/import/traktTv.ts
@@ -718,7 +718,6 @@ const findEpisodeOrSeason = (args: {
 const getMediaItemsByTmdbIds = async (
   ids: {
     trakt: number;
-    slug: string;
     tvdb: number;
     imdb: string;
     tmdb: number;

--- a/server/src/controllers/listsController.ts
+++ b/server/src/controllers/listsController.ts
@@ -130,7 +130,6 @@ export const getUserLists = async (args: {
     description: row.description,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
-    slug: row.slug,
     itemsCount: row.itemsCount,
     allowComments: Boolean(row.allowComments),
     displayNumbers: Boolean(row.displayNumbers),

--- a/server/src/entity/mediaItem.ts
+++ b/server/src/entity/mediaItem.ts
@@ -1,11 +1,8 @@
-import { parseISO } from 'date-fns';
-
 import { UserRating } from 'src/entity/userRating';
 import { Seen } from 'src/entity/seen';
 import { TvEpisode } from 'src/entity/tvepisode';
 import { TvSeason } from 'src/entity/tvseason';
 import { AudibleCountryCode } from 'src/entity/configuration';
-import { toSlug } from 'src/slug';
 import { List } from 'src/entity/list';
 
 export type MediaType = 'tv' | 'movie' | 'book' | 'video_game' | 'audiobook';
@@ -28,7 +25,6 @@ export type MediaItemBase = ExternalIds & {
   status?: string;
   platform?: string[];
   title: string;
-  slug?: string;
   originalTitle?: string;
   poster?: string;
   backdrop?: string;
@@ -159,7 +155,6 @@ export const mediaItemColumns = <const>[
   'numberOfPages',
   'traktId',
   'audibleCountryCode',
-  'slug',
   'tvdbId',
 ];
 
@@ -187,14 +182,4 @@ export const seasonPosterPath = (
     seasonId: seasonId.toString(),
     size: size,
   })}`;
-};
-
-export const mediaItemSlug = (mediaItem: MediaItemBase) => {
-  if (mediaItem.releaseDate) {
-    return toSlug(
-      `${mediaItem.title}-${parseISO(mediaItem.releaseDate).getFullYear()}`
-    );
-  } else {
-    return toSlug(mediaItem.title);
-  }
 };

--- a/server/src/knex/queries/items.ts
+++ b/server/src/knex/queries/items.ts
@@ -542,7 +542,6 @@ const mapRawResult = (row: any): MediaItemItemsResponse => {
       ? JSON.parse(row['mediaItem.platform'])
       : null,
     title: row['mediaItem.title'],
-    slug: row['mediaItem.slug'],
     originalTitle: row['mediaItem.originalTitle'],
     tmdbRating: row['mediaItem.tmdbRating'],
     runtime: row['mediaItem.runtime'],

--- a/server/src/migrations/20230514000000_dropMediaItemSlug.ts
+++ b/server/src/migrations/20230514000000_dropMediaItemSlug.ts
@@ -1,0 +1,208 @@
+import { Knex } from 'knex';
+import _ from 'lodash';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema
+    .alterTable('image', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('seasonId');
+    })
+    .alterTable('notificationsHistory', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('episodeId');
+    })
+    .alterTable('notificationPlatformsCredentials', (table) => {
+      table.dropForeign('userId');
+    })
+    .alterTable('accessToken', (table) => {
+      table.dropForeign('userId');
+    })
+    .alterTable('seen', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('episodeId');
+      table.dropForeign('userId');
+    })
+    .alterTable('progress', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('episodeId');
+      table.dropForeign('userId');
+    })
+    .alterTable('userRating', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('seasonId');
+      table.dropForeign('episodeId');
+      table.dropForeign('userId');
+    })
+    .alterTable('listItem', (table) => {
+      table.dropForeign('episodeId');
+      table.dropForeign('seasonId');
+      table.dropForeign('mediaItemId');
+      table.dropForeign('listId');
+    })
+    .alterTable('list', (table) => {
+      table.dropForeign('userId');
+    })
+    .alterTable('episode', (table) => {
+      table.dropForeign('tvShowId');
+      table.dropForeign('seasonId');
+    })
+    .alterTable('season', (table) => {
+      table.dropForeign('tvShowId');
+    });
+
+  await knex.schema.alterTable('mediaItem', (table) => {
+    table.dropUnique(['mediaType', 'slug']);
+    table.dropColumn('slug');
+  });
+
+  await knex.schema
+    .alterTable('season', (table) => {
+      table.foreign('tvShowId').references('id').inTable('mediaItem');
+    })
+    .alterTable('episode', (table) => {
+      table.foreign('tvShowId').references('id').inTable('mediaItem');
+      table.foreign('seasonId').references('id').inTable('season');
+    })
+    .alterTable('image', (table) => {
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('seasonId').references('id').inTable('season');
+    })
+    .alterTable('notificationsHistory', (table) => {
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('episodeId').references('id').inTable('episode');
+    })
+    .alterTable('list', (table) => {
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('listItem', (table) => {
+      table.foreign('episodeId').references('id').inTable('episode');
+      table.foreign('seasonId').references('id').inTable('season');
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('listId').references('id').inTable('list');
+    })
+    .alterTable('userRating', (table) => {
+      table.foreign('episodeId').references('id').inTable('episode');
+      table.foreign('seasonId').references('id').inTable('season');
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('seen', (table) => {
+      table.foreign('episodeId').references('id').inTable('episode');
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('accessToken', (table) => {
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('notificationPlatformsCredentials', (table) => {
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('progress', (table) => {
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('episodeId').references('id').inTable('episode');
+      table.foreign('userId').references('id').inTable('user');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema
+    .alterTable('image', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('seasonId');
+    })
+    .alterTable('notificationsHistory', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('episodeId');
+    })
+    .alterTable('notificationPlatformsCredentials', (table) => {
+      table.dropForeign('userId');
+    })
+    .alterTable('accessToken', (table) => {
+      table.dropForeign('userId');
+    })
+    .alterTable('seen', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('episodeId');
+      table.dropForeign('userId');
+    })
+    .alterTable('progress', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('episodeId');
+      table.dropForeign('userId');
+    })
+    .alterTable('userRating', (table) => {
+      table.dropForeign('mediaItemId');
+      table.dropForeign('seasonId');
+      table.dropForeign('episodeId');
+      table.dropForeign('userId');
+    })
+    .alterTable('listItem', (table) => {
+      table.dropForeign('episodeId');
+      table.dropForeign('seasonId');
+      table.dropForeign('mediaItemId');
+      table.dropForeign('listId');
+    })
+    .alterTable('list', (table) => {
+      table.dropForeign('userId');
+    })
+    .alterTable('episode', (table) => {
+      table.dropForeign('tvShowId');
+      table.dropForeign('seasonId');
+    })
+    .alterTable('season', (table) => {
+      table.dropForeign('tvShowId');
+    });
+
+  await knex.schema.alterTable('mediaItem', (table) => {
+    table.text('slug');
+    table.unique(['mediaType', 'slug']);
+  });
+
+  await knex.schema
+    .alterTable('season', (table) => {
+      table.foreign('tvShowId').references('id').inTable('mediaItem');
+    })
+    .alterTable('episode', (table) => {
+      table.foreign('tvShowId').references('id').inTable('mediaItem');
+      table.foreign('seasonId').references('id').inTable('season');
+    })
+    .alterTable('image', (table) => {
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('seasonId').references('id').inTable('season');
+    })
+    .alterTable('notificationsHistory', (table) => {
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('episodeId').references('id').inTable('episode');
+    })
+    .alterTable('list', (table) => {
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('listItem', (table) => {
+      table.foreign('episodeId').references('id').inTable('episode');
+      table.foreign('seasonId').references('id').inTable('season');
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('listId').references('id').inTable('list');
+    })
+    .alterTable('userRating', (table) => {
+      table.foreign('episodeId').references('id').inTable('episode');
+      table.foreign('seasonId').references('id').inTable('season');
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('seen', (table) => {
+      table.foreign('episodeId').references('id').inTable('episode');
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('accessToken', (table) => {
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('notificationPlatformsCredentials', (table) => {
+      table.foreign('userId').references('id').inTable('user');
+    })
+    .alterTable('progress', (table) => {
+      table.foreign('mediaItemId').references('id').inTable('mediaItem');
+      table.foreign('episodeId').references('id').inTable('episode');
+      table.foreign('userId').references('id').inTable('user');
+    });
+}

--- a/server/src/repository/list.ts
+++ b/server/src/repository/list.ts
@@ -21,7 +21,6 @@ export type ListDetailsResponse = Omit<List, 'userId'> & {
   user: {
     id: number;
     username: string;
-    slug: string;
   };
 };
 
@@ -174,7 +173,7 @@ class ListRepository extends repository<List>({
     const { listId, userId } = args;
 
     const res = await Database.knex('list')
-      .select('list.*', 'user.name AS user.name', 'user.slug AS user.slug')
+      .select('list.*', 'user.name AS user.name')
       .where('list.id', listId)
       .where((qb) =>
         qb.where('list.userId', userId).orWhere('list.privacy', 'public')
@@ -261,7 +260,6 @@ class ListRepository extends repository<List>({
       user: {
         id: res.userId,
         username: res['user.name'],
-        slug: res['user.slug'],
       },
     };
   }
@@ -390,7 +388,6 @@ class ListRepository extends repository<List>({
         'mediaItem.runtime': 'mediaItem.runtime',
         'mediaItem.seenEpisodesCount':
           'mediaItemSeenEpisodes.seenEpisodesCount',
-        'mediaItem.slug': 'mediaItem.slug',
         'mediaItem.status': 'mediaItem.status',
         'mediaItem.source': 'mediaItem.source',
         'mediaItem.title': 'mediaItem.title',
@@ -921,7 +918,6 @@ class ListRepository extends repository<List>({
           : undefined,
         releaseDate: listItem['mediaItem.releaseDate'],
         runtime: listItem['mediaItem.runtime'] || null,
-        slug: listItem['mediaItem.slug'],
         source: listItem['mediaItem.source'],
         progress: listItem['mediaItem.progress'],
         status: listItem['mediaItem.status']?.toLowerCase(),

--- a/server/src/repository/user.ts
+++ b/server/src/repository/user.ts
@@ -91,7 +91,7 @@ class UserRepository extends repository<User>({
     return await Database.knex<User>(this.tableName).where(where).first();
   }
 
-  public async create(user: Omit<User, 'id' | 'slug'>) {
+  public async create(user: Omit<User, 'id'>) {
     user.password = await argon2.hash(user.password);
 
     const res = await Database.knex.transaction(async (trx) => {


### PR DESCRIPTION
Remove `slug` from `mediaItem`. This is the last update of purging `slug`. `slug` only creates unnecessary complexity for this simple application, it is not worth the effort of maintaining it and it was never used in the client