### PR TITLE
Re-organize the top nav

### DIFF
--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -83,13 +83,13 @@ export const NavComponent: FunctionComponent = () => {
                         expand_more
                       </i>
                     </button>
-                    <nav className="absolute z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700">
+                    <nav className="absolute z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-neutral-700 dark:text-white">
                         <ul className="py-2 flex flex-col flex-grow" aria-labelledby="dropdownDefaultButton">
                         {libraryRoutes.map((route) =>
                           <li key={route.path}>
-                            <a href={route.path} className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+                            <NavLink to={route.path} className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-neutral-800 dark:hover:text-white">
                               {route.name}
-                            </a>
+                            </NavLink>
                           </li>
                         )}
                         </ul>
@@ -120,9 +120,9 @@ export const NavComponent: FunctionComponent = () => {
                       expand_more
                     </i>
                   </a>
-                  <nav className="absolute top-6 right-0 z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-36 dark:bg-gray-700">
+                  <nav className="absolute top-6 right-0 z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-neutral-700 dark:text-white">
                       <ul className="py-2 flex flex-col flex-grow text-right" aria-labelledby="dropdownDefaultButton">
-                        <li className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+                        <li className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-neutral-800 dark:hover:text-white">
                           <span
                             onClick={() => setDarkMode(!darkMode)}
                             className="cursor-pointer select-none"
@@ -135,17 +135,17 @@ export const NavComponent: FunctionComponent = () => {
                         </li>
                         {userRoutes.map((route) =>
                           <li key={route.path}>
-                            <a href={route.path} className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+                            <NavLink to={route.path} className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-neutral-800 dark:hover:text-white">
                               {route.name}
                               <i className=" ml-2 select-none material-icons">
                                 {route.icon}
                               </i>
-                            </a>
+                            </NavLink>
                           </li>
                         )}
                         <li>
                           <a
-                            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+                            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-neutral-800 dark:hover:text-white"
                             href="/logout"
                             onClick={(e) => {
                               e.preventDefault();

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -94,6 +94,9 @@ export const NavComponent: FunctionComponent = () => {
                       className="border-none" 
                       type="button">
                       Library
+                      <i className=" ml-2 text-sm select-none material-icons">
+                        expand_more
+                      </i>
                     </button>
                     <nav className="absolute z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700">
                         <ul className="py-2 flex flex-col flex-grow" aria-labelledby="dropdownDefaultButton">
@@ -128,7 +131,7 @@ export const NavComponent: FunctionComponent = () => {
                 <DropDown className="ml-auto flex items-center">
                   <a href="#/settings">
                     {user.name}
-                    <i className=" ml-2 select-none material-icons">
+                    <i className=" ml-2 text-sm select-none material-icons">
                       expand_more
                     </i>
                   </a>

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -37,68 +37,69 @@ export const NavComponent: FunctionComponent = () => {
     <>
       {user ? (
         <>
-          <nav className="flex items-center">
-            <div className="hidden md:block">
-              <div className="flex flex-col md:flex-row">
-                {routes.map((route) => (
-                  <span
-                    key={route.path}
-                    className="m-1 mr-2 text-xl whitespace-nowrap"
-                  >
-                    <NavLink
-                      to={route.path}
-                      className={({ isActive }) =>
-                        clsx(isActive && 'underline')
-                      }
-                    >
-                      {route.name}
-                    </NavLink>
-                  </span>
-                ))}
-              </div>
-            </div>
+          <nav className="border-b-2">
+            <div className="container mx-auto py-3 py-3">
+              <div className="flex">
+                <div className="lg:hidden">
+                  <div className="flex flex-col lg:flex-row">
+                    {routes
+                      .filter((route) => route.path === location.pathname)
+                      .map((route) => (
+                        <span
+                          key={route.path}
+                          className="m-1 mr-2 text-xl whitespace-nowrap"
+                        >
+                          {route.name}
+                        </span>
+                      ))}
+                  </div>
+                </div>
 
-            <div className="md:hidden">
-              <div className="flex flex-col md:flex-row">
-                {routes
-                  .filter((route) => route.path === location.pathname)
-                  .map((route) => (
+                <div className="hidden lg:flex">
+                  {routes.map((route) => (
                     <span
                       key={route.path}
-                      className="m-1 mr-2 text-xl whitespace-nowrap"
+                      className="mr-3 text-xl whitespace-nowrap"
                     >
-                      {route.name}
+                      <NavLink
+                        to={route.path}
+                        className={({ isActive }) =>
+                          clsx(isActive && 'underline')
+                        }
+                      >
+                        {route.name}
+                      </NavLink>
                     </span>
                   ))}
+                </div>
+
+                <div className="ml-auto flex">
+                  <span
+                    onClick={() => setDarkMode(!darkMode)}
+                    className="pr-2 cursor-pointer select-none material-icons"
+                  >
+                    {darkMode ? <>light_mode</> : <>mode_night</>}
+                  </span>
+                  <a href="#/settings">{user.name}</a>
+                  <span className="px-1">|</span>
+                  <a
+                    href="/logout"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      logout();
+                    }}
+                  >
+                    <Trans>Logout</Trans>
+                  </a>
+                  <span
+                    className="flex px-2 cursor-pointer lg:hidden material-icons"
+                    onClick={() => setShowSidebar(!showSidebar)}
+                  >
+                    {showSidebar ? 'menu_open' : 'menu'}
+                  </span>
+                </div>
               </div>
             </div>
-
-            <div className="inline-flex ml-auto mr-2 whitespace-nowrap">
-              <span
-                onClick={() => setDarkMode(!darkMode)}
-                className="pr-2 cursor-pointer select-none material-icons"
-              >
-                {darkMode ? <>light_mode</> : <>mode_night</>}
-              </span>
-              <a href="#/settings">{user.name}</a>
-              <span className="px-1">|</span>
-              <a
-                href="/logout"
-                onClick={(e) => {
-                  e.preventDefault();
-                  logout();
-                }}
-              >
-                <Trans>Logout</Trans>
-              </a>
-            </div>
-
-            <span
-              className="flex px-2 cursor-pointer md:hidden material-icons"
-              onClick={() => setShowSidebar(!showSidebar)}
-            >
-              {showSidebar ? 'menu_open' : 'menu'}
-            </span>
           </nav>
 
           <SideBar

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -212,6 +212,7 @@ const SideBar: FunctionComponent<{
 }> = (props) => {
   const { showSidebar, hideSidebar } = props;
   const routes = useRouteNames();
+  const { logout } = useUser();
 
   return (
     <Transition
@@ -263,6 +264,18 @@ const SideBar: FunctionComponent<{
                       </NavLink>
                     </span>
                   ))}
+                  <span className="my-2 ml-1 mr-3 text-xl">
+                    <a
+                      className=""
+                      href="/logout"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        logout();
+                      }}
+                    >
+                      <Trans>Logout</Trans>
+                    </a>
+                  </span>
                 </div>
               </animated.div>
             </>

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -3,26 +3,49 @@ import clsx from 'clsx';
 import { t, Trans } from '@lingui/macro';
 import { NavLink, useLocation } from 'react-router-dom';
 import { animated, Transition, Spring } from '@react-spring/web';
+import styled from 'styled-components';
 
 import { useUser } from 'src/api/user';
 import { useDarkMode } from 'src/hooks/darkMode';
 
+const libraryRoutes = [
+  { path: '/tv', name: t`Tv` },
+  { path: '/movies', name: t`Movies` },
+  { path: '/games', name: t`Games` },
+  { path: '/books', name: t`Books` },
+  { path: '/audiobooks', name: t`Audiobooks` },
+];
+const extraRoutes = [
+  { path: '/in-progress', name: t`In progress` },
+  { path: '/watchlist', name: t`Watchlist` },
+];
+const userRoutes = [
+    { path: '/upcoming', name: t`Upcoming`, icon: 'event' },
+    { path: '/calendar', name: t`Calendar`, icon: 'calendar_month' },
+    { path: '/import', name: t`Import`, icon: 'file_upload' },
+    { path: '/lists', name: t`Lists`, icon: 'list' },
+    { path: '/settings', name: t`Settings`, icon: 'settings' },
+];
+
 export const useRouteNames = () => {
   return [
     { path: '/', name: t`Home` },
-    { path: '/tv', name: t`Tv` },
-    { path: '/movies', name: t`Movies` },
-    { path: '/games', name: t`Games` },
-    { path: '/books', name: t`Books` },
-    { path: '/audiobooks', name: t`Audiobooks` },
-    { path: '/upcoming', name: t`Upcoming` },
-    { path: '/in-progress', name: t`In progress` },
-    { path: '/watchlist', name: t`Watchlist` },
-    { path: '/calendar', name: t`Calendar` },
-    { path: '/import', name: t`Import` },
-    { path: '/lists', name: t`Lists` },
+    ...libraryRoutes,
+    ...userRoutes,
   ];
 };
+
+const DropDown = styled.div`
+  position: relative;
+  nav {
+    display: none;
+  }
+  &:hover {
+    nav {
+      display: flex;
+    }
+  }
+`;
 
 export const NavComponent: FunctionComponent = () => {
   const { user, logout } = useUser();
@@ -42,6 +65,7 @@ export const NavComponent: FunctionComponent = () => {
               <div className="flex">
                 <div className="lg:hidden">
                   <div className="flex flex-col lg:flex-row">
+                  hi
                     {routes
                       .filter((route) => route.path === location.pathname)
                       .map((route) => (
@@ -55,11 +79,39 @@ export const NavComponent: FunctionComponent = () => {
                   </div>
                 </div>
 
-                <div className="hidden lg:flex">
-                  {routes.map((route) => (
+                <div className="hidden lg:flex text-l">
+                  <NavLink
+                    to='/'
+                    className={({ isActive }) =>
+                      clsx(isActive && 'underline')
+                    }
+                  >
+                    {t`Home`}
+                  </NavLink>
+
+                  <DropDown className="ml-4">
+                    <button
+                      className="border-none" 
+                      type="button">
+                      Library
+                    </button>
+                    <nav className="absolute z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700">
+                        <ul className="py-2 flex flex-col flex-grow" aria-labelledby="dropdownDefaultButton">
+                        {libraryRoutes.map((route) =>
+                          <li key={route.path}>
+                            <a href={route.path} className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+                              {route.name}
+                            </a>
+                          </li>
+                        )}
+                        </ul>
+                    </nav>
+                  </DropDown>
+
+                  {extraRoutes.map((route) => (
                     <span
                       key={route.path}
-                      className="mr-3 text-xl whitespace-nowrap"
+                      className="ml-4 whitespace-nowrap"
                     >
                       <NavLink
                         to={route.path}
@@ -73,31 +125,54 @@ export const NavComponent: FunctionComponent = () => {
                   ))}
                 </div>
 
-                <div className="ml-auto flex">
-                  <span
-                    onClick={() => setDarkMode(!darkMode)}
-                    className="pr-2 cursor-pointer select-none material-icons"
-                  >
-                    {darkMode ? <>light_mode</> : <>mode_night</>}
-                  </span>
-                  <a href="#/settings">{user.name}</a>
-                  <span className="px-1">|</span>
-                  <a
-                    href="/logout"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      logout();
-                    }}
-                  >
-                    <Trans>Logout</Trans>
+                <DropDown className="ml-auto flex items-center">
+                  <a href="#/settings">
+                    {user.name}
+                    <i className=" ml-2 select-none material-icons">
+                      expand_more
+                    </i>
                   </a>
-                  <span
-                    className="flex px-2 cursor-pointer lg:hidden material-icons"
-                    onClick={() => setShowSidebar(!showSidebar)}
-                  >
-                    {showSidebar ? 'menu_open' : 'menu'}
-                  </span>
-                </div>
+                  <nav className="absolute top-6 right-0 z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-36 dark:bg-gray-700">
+                      <ul className="py-2 flex flex-col flex-grow text-right" aria-labelledby="dropdownDefaultButton">
+                        <li className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+                          <span
+                            onClick={() => setDarkMode(!darkMode)}
+                            className="cursor-pointer select-none"
+                          >
+                            {darkMode ? <>Light</> : <>Dark</>} mode
+                            <i className=" ml-2 select-none material-icons">
+                              {darkMode ? <>light_mode</> : <>mode_night</>}
+                            </i>
+                          </span>
+                        </li>
+                        {userRoutes.map((route) =>
+                          <li key={route.path}>
+                            <a href={route.path} className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+                              {route.name}
+                              <i className=" ml-2 select-none material-icons">
+                                {route.icon}
+                              </i>
+                            </a>
+                          </li>
+                        )}
+                        <li>
+                          <a
+                            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+                            href="/logout"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              logout();
+                            }}
+                          >
+                            <Trans>Logout</Trans>
+                            <i className=" ml-2 select-none material-icons">
+                              logout
+                            </i>
+                          </a>
+                        </li>
+                      </ul>
+                  </nav>
+                </DropDown>
               </div>
             </div>
           </nav>

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -62,7 +62,7 @@ export const NavComponent: FunctionComponent = () => {
         <>
           <nav className="border-b-2">
             <div className="container mx-auto py-3 py-3">
-              <div className="hidden lg:flex flex-row text-l">
+              <div className="hidden md:flex flex-row text-l">
               { /* Start desktop nav */ }
                 <div className="flex flex-row">
                   <NavLink
@@ -165,7 +165,7 @@ export const NavComponent: FunctionComponent = () => {
               { /* End desktop nav */ }
 
               { /* Start mobile nav */ }
-              <div className="flex flex-row lg:hidden">
+              <div className="flex flex-row md:hidden">
                 <NavLink
                   to='/'
                   className={({ isActive }) =>

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -62,24 +62,9 @@ export const NavComponent: FunctionComponent = () => {
         <>
           <nav className="border-b-2">
             <div className="container mx-auto py-3 py-3">
-              <div className="flex">
-                <div className="lg:hidden">
-                  <div className="flex flex-col lg:flex-row">
-                  hi
-                    {routes
-                      .filter((route) => route.path === location.pathname)
-                      .map((route) => (
-                        <span
-                          key={route.path}
-                          className="m-1 mr-2 text-xl whitespace-nowrap"
-                        >
-                          {route.name}
-                        </span>
-                      ))}
-                  </div>
-                </div>
-
-                <div className="hidden lg:flex text-l">
+              <div className="hidden lg:flex flex-row text-l">
+              { /* Start desktop nav */ }
+                <div className="flex flex-row">
                   <NavLink
                     to='/'
                     className={({ isActive }) =>
@@ -177,6 +162,26 @@ export const NavComponent: FunctionComponent = () => {
                   </nav>
                 </DropDown>
               </div>
+              { /* End desktop nav */ }
+
+              { /* Start mobile nav */ }
+              <div className="flex flex-row lg:hidden">
+                <NavLink
+                  to='/'
+                  className={({ isActive }) =>
+                    clsx(isActive && 'underline')
+                  }
+                >
+                  {t`Home`}
+                </NavLink>
+                <button className="px-4 ml-auto"
+                  onClick={() => setShowSidebar(true)}>
+                  <i className="text-sm select-none material-icons">
+                    menu
+                  </i>
+                </button>
+              </div>
+              { /* End mobile nav */ }
             </div>
           </nav>
 


### PR DESCRIPTION
(Hi there! 👋 thank you for this project, it's really cool. I did some unsolicited design improvements, but feel free to close this PR if you don't want them)

### Changes
- Puts the content of the header inside a tailwind container
- Moves the Tv, Movies, Games, Books and Audiobooks to a header item named "Library". Maintains the In Progress and Watchlist items
- Moves the Dark Mode, Upcoming, Calendar, Import, Lists, Settings and Logout to a header item under the user's name

### Before
![Screenshot 2023-05-30 at 18 53 16](https://github.com/bonukai/MediaTracker/assets/8152526/3b147a54-e2a6-4809-bb88-0f0f6b43ccca)

### After
![Screenshot 2023-05-30 at 18 46 52](https://github.com/bonukai/MediaTracker/assets/8152526/b4402464-0959-439a-b12a-37004cef4421)

### Dropdowns

<img width="401" alt="Screenshot 2023-05-30 at 18 13 57" src="https://github.com/bonukai/MediaTracker/assets/8152526/480a020f-b615-42df-9348-42f036c11bd8">

<img width="303" alt="Screenshot 2023-05-30 at 18 13 51" src="https://github.com/bonukai/MediaTracker/assets/8152526/ee4d5f55-6034-4ec2-b5c4-907b4d7f016b">

