### PR TITLE
fix bug in notifications migration

### DIFF
--- a/src/migrations/20240404000000_notificationPlatforms.ts
+++ b/src/migrations/20240404000000_notificationPlatforms.ts
@@ -20,6 +20,8 @@ export async function up(knex: Knex): Promise<void> {
             ([platformName, value]: [string, unknown]) => ({
               id: nanoid(),
               name: platformName,
+              addedAt: null,
+              description: null,
               credentials:
                 value && typeof value === 'object' && 'credentials' in value
                   ? value.credentials


### PR DESCRIPTION
`notificationPlatform` object should contain (nullable) attributes `addedAt` and `description`