### PR TITLE
Convert all release dates to ISO

### DIFF
--- a/client/src/components/MediaItemActionButtons.tsx
+++ b/client/src/components/MediaItemActionButtons.tsx
@@ -1,4 +1,3 @@
-import { parseISO } from 'date-fns';
 import React, { FC, ReactNode, useEffect, useState } from 'react';
 
 import { Plural, Trans } from '@lingui/macro';
@@ -51,7 +50,7 @@ const AddEpisodeToSeenHistoryAction = dialogActionFactory<{
               date:
                 date === 'release_date'
                   ? episode.releaseDate
-                    ? parseISO(episode.releaseDate).getTime()
+                    ? new Date(episode.releaseDate).getTime()
                     : null
                   : date?.getTime(),
             },
@@ -109,7 +108,7 @@ const AddRegularMediaItemToSeenHistoryAction = dialogActionFactory<{
           date:
             date === 'release_date'
               ? mediaItem.releaseDate
-                ? parseISO(mediaItem.releaseDate).getTime()
+                ? new Date(mediaItem.releaseDate).getTime()
                 : null
               : date?.getTime(),
         });
@@ -357,7 +356,7 @@ export const AddTvShowToSeenHistoryAction = dialogActionFactory<{
                                   date:
                                     date === 'release_date'
                                       ? episode.releaseDate
-                                        ? parseISO(
+                                        ? new Date(
                                             episode.releaseDate
                                           ).getTime()
                                         : null
@@ -494,7 +493,7 @@ export const AddSingleEpisodeToSeenHistoryAction = dialogActionFactory<{
                                   date:
                                     date === 'release_date'
                                       ? selectedEpisode.releaseDate
-                                        ? parseISO(
+                                        ? new Date(
                                             selectedEpisode.releaseDate
                                           ).getTime()
                                         : null
@@ -570,8 +569,10 @@ const EpisodeSelector: FC<{
   useEffect(() => {
     setSelectedSeasonId(seasons?.at(-1)?.id);
 
-    const episodeId = seasons?.at(-1)?.episodes?.filter(hasBeenReleased)?.at(-1)
-      ?.id;
+    const episodeId = seasons
+      ?.at(-1)
+      ?.episodes?.filter(hasBeenReleased)
+      ?.at(-1)?.id;
 
     if (typeof episodeId === 'number') {
       setSelectedEpisodeId(episodeId);

--- a/client/src/components/MediaItemViews.tsx
+++ b/client/src/components/MediaItemViews.tsx
@@ -1,4 +1,4 @@
-import { isSameDay, parseISO } from 'date-fns';
+import { isSameDay } from 'date-fns';
 import { minBy } from 'lodash';
 import { FC, Fragment } from 'react';
 import { Link } from 'react-router-dom';
@@ -74,7 +74,7 @@ const MovieReleaseType: FC<{ mediaItem: MediaItemResponse }> = (props) => {
     firstReleaseDate.date &&
     releaseDates.filter((item) => item.date === firstReleaseDate.date)
       .length === 1 &&
-    isSameDay(parseISO(mediaItem.releaseDate), parseISO(firstReleaseDate.date))
+    isSameDay(new Date(mediaItem.releaseDate), new Date(firstReleaseDate.date))
   ) {
     return firstReleaseDate.type;
   }
@@ -96,7 +96,7 @@ const MediaItemNextAiringText: FC<{ mediaItem: MediaItemResponse }> = (
             <span> </span>
             <span className="font-semibold">
               <RelativeTime
-                to={parseISO(mediaItem.upcomingEpisode.releaseDate)}
+                to={new Date(mediaItem.upcomingEpisode.releaseDate)}
               />
             </span>
           </Trans>
@@ -107,7 +107,7 @@ const MediaItemNextAiringText: FC<{ mediaItem: MediaItemResponse }> = (
           <Trans>
             <MovieReleaseType mediaItem={mediaItem} />{' '}
             <span className="font-semibold">
-              <RelativeTime to={parseISO(mediaItem.releaseDate)} />
+              <RelativeTime to={new Date(mediaItem.releaseDate)} />
             </span>
           </Trans>
         </div>
@@ -130,7 +130,7 @@ const MediaItemLastAiringText: FC<{ mediaItem: MediaItemResponse }> = (
             released{' '}
             <span className="font-semibold">
               <RelativeTime
-                to={parseISO(mediaItem.lastAiredEpisode.releaseDate)}
+                to={new Date(mediaItem.lastAiredEpisode.releaseDate)}
               />
             </span>
           </Trans>
@@ -142,7 +142,7 @@ const MediaItemLastAiringText: FC<{ mediaItem: MediaItemResponse }> = (
           <Trans>
             released{' '}
             <span className="font-semibold">
-              <RelativeTime to={parseISO(mediaItem.releaseDate)} />
+              <RelativeTime to={new Date(mediaItem.releaseDate)} />
             </span>
           </Trans>
         </div>

--- a/client/src/components/SelectSeenDateComponent.tsx
+++ b/client/src/components/SelectSeenDateComponent.tsx
@@ -1,4 +1,4 @@
-import { format, parseISO } from 'date-fns';
+import { format } from 'date-fns';
 import { FC } from 'react';
 
 import { Trans } from '@lingui/macro';
@@ -179,10 +179,10 @@ const getItemReleaseDate = (args: {
       return;
     }
 
-    return parseISO(episode.releaseDate);
+    return new Date(episode.releaseDate);
   }
 
   if (hasReleaseDate(mediaItem)) {
-    return parseISO(mediaItem.releaseDate);
+    return new Date(mediaItem.releaseDate);
   }
 };

--- a/client/src/mediaItemHelpers.ts
+++ b/client/src/mediaItemHelpers.ts
@@ -1,5 +1,3 @@
-import { parseISO } from 'date-fns';
-
 import { t } from '@lingui/macro';
 
 import type {
@@ -23,7 +21,7 @@ export const hasBeenReleased = (value: {
 }): boolean => {
   return (
     typeof value.releaseDate === 'string' &&
-    parseISO(value.releaseDate) <= new Date()
+    new Date(value.releaseDate) <= new Date()
   );
 };
 
@@ -156,7 +154,7 @@ export const releaseYear = (
     return;
   }
 
-  return parseISO(mediaItem.releaseDate).getFullYear();
+  return new Date(mediaItem.releaseDate).getFullYear();
 };
 
 export const posterAspectRatio = (mediaItem: MediaItemResponse) => {

--- a/client/src/pages/CalendarPage.tsx
+++ b/client/src/pages/CalendarPage.tsx
@@ -1,4 +1,4 @@
-import { addMonths, parseISO, subMonths } from 'date-fns';
+import { addMonths, subMonths } from 'date-fns';
 import { FC, ReactNode, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -76,7 +76,7 @@ const JsonIconButton: FC = () => {
   return (
     <CopyApiUrlAction
       dialogTitle={<Trans>JSON url</Trans>}
-      tokenMutationArgs={{ type: 'calendar-rss' }}
+      tokenMutationArgs={{ type: 'calendar-json' }}
     >
       <Button text={<Trans>JSON url</Trans>} />
     </CopyApiUrlAction>
@@ -115,7 +115,7 @@ export const CalendarPage: FC = () => {
       <Calendar
         onDateChange={(from, to) => setCurrentDate({ from, to })}
         items={calendarItems?.data?.map((item) => ({
-          date: parseISO(item.releaseDate),
+          date: new Date(item.releaseDate),
           item: item,
           key: [
             item.mediaItem.id,

--- a/client/src/pages/DetailsPage.tsx
+++ b/client/src/pages/DetailsPage.tsx
@@ -1,4 +1,3 @@
-import { parseISO } from 'date-fns';
 import { FC, ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
 
@@ -192,7 +191,7 @@ const InfoSection: FC<{ mediaItem: MediaItemResponse }> = (props) => {
       {hasReleaseDate(mediaItem) && (
         <div>
           <Trans>
-            Release date: {parseISO(mediaItem.releaseDate).toLocaleDateString()}
+            Release date: {new Date(mediaItem.releaseDate).toLocaleDateString()}
           </Trans>
         </div>
       )}

--- a/src/entity/episodeModel.ts
+++ b/src/entity/episodeModel.ts
@@ -1,4 +1,3 @@
-import { parseISO } from 'date-fns';
 import { z } from 'zod';
 
 export const episodeModelSchema = z.object({
@@ -32,7 +31,7 @@ export class TvEpisodeFilters {
     return (
       typeof episode.releaseDate === 'string' &&
       episode.releaseDate.trim() != '' &&
-      parseISO(episode.releaseDate) <= new Date()
+      new Date(episode.releaseDate) <= new Date()
     );
   };
 
@@ -40,7 +39,7 @@ export class TvEpisodeFilters {
     return (
       typeof episode.releaseDate !== 'string' ||
       episode.releaseDate.trim() == '' ||
-      parseISO(episode.releaseDate) > new Date()
+      new Date(episode.releaseDate) > new Date()
     );
   };
 }

--- a/src/metadata/provider/TVmaze.ts
+++ b/src/metadata/provider/TVmaze.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { MediaItemMetadata } from '../../entity/mediaItemModel.js';
 import { logger } from '../../logger.js';
 import { requestQueueFactory } from '../../requestQueue.js';
-import { dumpFetchResponse, h } from '../../utils.js';
+import { dumpFetchResponse, h, tryParseDate } from '../../utils.js';
 import { metadataProviderFactory } from '../metadataProvider.js';
 
 export const TVmaze = metadataProviderFactory({
@@ -57,7 +57,7 @@ export const TVmaze = metadataProviderFactory({
       overview: data.summary,
       language: data.language,
       genres: data.genres,
-      releaseDate: data.premiered,
+      releaseDate: tryParseDate(data.premiered)?.toISOString(),
       status: data.status,
       url: data.officialSite,
       network: data.network?.name,
@@ -69,7 +69,7 @@ export const TVmaze = metadataProviderFactory({
         title: season.name || `Season ${season.number}`,
         description: season.summary,
         externalPosterUrl: season.image?.medium,
-        releaseDate: season.premiereDate,
+        releaseDate: tryParseDate(season.premiereDate)?.toISOString(),
         episodes: data._embedded.episodes
           .filter((episode) => episode.season === season.number)
           .map((episode) => ({
@@ -77,7 +77,7 @@ export const TVmaze = metadataProviderFactory({
             description: episode.summary,
             episodeNumber: episode.number,
             seasonNumber: episode.season,
-            releaseDate: episode.airstamp,
+            releaseDate: tryParseDate(episode.airstamp)?.toISOString(),
             isSpecialEpisode: episode.type === 'insignificant_special',
             runtime: episode.runtime,
           })),

--- a/src/metadata/provider/audible.ts
+++ b/src/metadata/provider/audible.ts
@@ -7,7 +7,7 @@ import {
 import { MediaItemMetadata } from '../../entity/mediaItemModel.js';
 import { getConfiguration } from '../../repository/configurationRepository.js';
 import { metadataProviderFactory } from '../metadataProvider.js';
-import { dumpFetchResponse } from '../../utils.js';
+import { dumpFetchResponse, tryParseDate } from '../../utils.js';
 
 const languages: Record<AudibleCountryCode, string> = {
   au: 'au',
@@ -120,7 +120,7 @@ const mapItemResponse = (
     narrators: item.narrators?.map((narrator) => narrator.name),
     externalPosterUrl: item.product_images?.[2400],
     language: item.language,
-    releaseDate: item.release_date,
+    releaseDate: tryParseDate(item.release_date)?.toISOString(),
     runtime: item.runtime_length_min,
     overview: item.merchandising_summary,
   };

--- a/src/metadata/provider/tmdbMovie.ts
+++ b/src/metadata/provider/tmdbMovie.ts
@@ -1,10 +1,9 @@
-import { parseISO } from 'date-fns';
 import _ from 'lodash';
 import { z } from 'zod';
 
 import { MediaItemMetadata } from '../../entity/mediaItemModel.js';
 import { getConfiguration } from '../../repository/configurationRepository.js';
-import { dumpFetchResponse } from '../../utils.js';
+import { dumpFetchResponse, tryParseDate } from '../../utils.js';
 import { metadataProviderFactory } from '../metadataProvider.js';
 import {
   createTmdbFullImageUrl,
@@ -140,7 +139,7 @@ const mapMovie = (movie: {
   title: movie.title,
   originalTitle: movie.original_title || null,
   overview: movie.overview || null,
-  releaseDate: movie.release_date || null,
+  releaseDate: tryParseDate(movie.release_date)?.toISOString(),
   tmdbId: movie.id,
   tmdbRating: movie.vote_average || null,
   language: movie.original_language || null,
@@ -303,16 +302,10 @@ const movieDetailsToMediaItemMetadata = async (
     runtime: movie.runtime || null,
     status: movie.status || null,
     url: movie.homepage || null,
-    theatricalReleaseDate: theatricalReleaseDate
-      ? parseISO(theatricalReleaseDate)
-      : null,
-    physicalReleaseDate: digitalReleaseDate
-      ? parseISO(digitalReleaseDate)
-      : null,
-    digitalReleaseDate: physicalReleaseDate
-      ? parseISO(physicalReleaseDate)
-      : null,
-    tvReleaseDate: tvReleaseDate ? parseISO(tvReleaseDate) : null,
+    theatricalReleaseDate: tryParseDate(theatricalReleaseDate),
+    physicalReleaseDate: tryParseDate(digitalReleaseDate),
+    digitalReleaseDate: tryParseDate(physicalReleaseDate),
+    tvReleaseDate: tryParseDate(tvReleaseDate),
     justWatch: parseJustWatchResult(configuration, movie['watch/providers']),
     needsDetails: false,
   };

--- a/src/migrations/20240515000000_convertReleaseDateToIsoUtc.ts
+++ b/src/migrations/20240515000000_convertReleaseDateToIsoUtc.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex('mediaItem').where('releaseDate', '').update('releaseDate', null);
+
+  const mediaItemsWithReleaseDate =
+    await knex('mediaItem').whereNotNull('releaseDate');
+
+  for (const mediaItem of mediaItemsWithReleaseDate) {
+    try {
+      await knex('mediaItem')
+        .where('id', mediaItem.id)
+        .update('releaseDate', new Date(mediaItem.releaseDate!).toISOString());
+    } catch {
+      await knex('mediaItem')
+        .where('id', mediaItem.id)
+        .update('releaseDate', null);
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {}

--- a/src/releaseNotifications.ts
+++ b/src/releaseNotifications.ts
@@ -1,4 +1,4 @@
-import { addHours, formatISO, min, parseISO, subHours } from 'date-fns';
+import { addHours, formatISO, min, subHours } from 'date-fns';
 import _ from 'lodash';
 
 import { i18n } from '@lingui/core';
@@ -33,7 +33,7 @@ export const sendAndScheduledNotificationsForReleases = async () => {
     .first();
 
   const nextTvUpdate = firstNextEpisode?.releaseDate
-    ? parseISO(firstNextEpisode.releaseDate)
+    ? new Date(firstNextEpisode.releaseDate)
     : nextDay;
 
   const firstNonTv = await Database.knex('mediaItem')
@@ -42,7 +42,7 @@ export const sendAndScheduledNotificationsForReleases = async () => {
     .first();
 
   const nextNonTvUpdate = firstNonTv?.releaseDate
-    ? parseISO(firstNonTv.releaseDate)
+    ? new Date(firstNonTv.releaseDate)
     : nextDay;
 
   const nextScheduleDate = min([nextTvUpdate, nextNonTvUpdate]);
@@ -329,7 +329,7 @@ const sendNotificationsForTvShows = async () => {
       _(episodes)
         .groupBy((episode) => episode.tvShowId)
         .mapValues((episodes) => ({
-          releaseDate: parseISO(episodes[0].releaseDate),
+          releaseDate: new Date(episodes[0].releaseDate),
           mediaItem: getTvShow(episodes[0].tvShowId),
           episodes,
           usersToSend: (mediaItemUserMap[episodes[0].tvShowId] || []).filter(

--- a/src/repository/listRepository.ts
+++ b/src/repository/listRepository.ts
@@ -16,7 +16,7 @@ import {
 } from '../entity/listModel.js';
 import { Knex } from 'knex';
 
-import { is, toReleaseDateFormat } from '../utils.js';
+import { is } from '../utils.js';
 import { mediaItemRepository } from './mediaItemRepository.js';
 import { TRPCError } from '@trpc/server';
 
@@ -325,6 +325,7 @@ export const listRepository = {
         .where('listId', listId)
         .leftJoin('mediaItem', 'listItem.mediaItemId', 'mediaItem.id')
         .modify((qb) => filterQuery(qb, args))
+        .modify((qb) => sortQuery(qb, args))
         .count({ count: '*' });
 
       const listItems: ListItemModel[] = await trx('listItem')
@@ -595,7 +596,7 @@ const sortQuery = <T extends object>(
   const sortOrder = args.sortOrder || 'asc';
   const orderBy = args.orderBy || 'listed';
 
-  const currentDateString = toReleaseDateFormat(new Date());
+  const currentDateString = new Date().toISOString();
 
   if (orderBy === 'listed') {
     query.orderBy('addedAt', sortOrder);

--- a/src/repository/mediaItemRepository.ts
+++ b/src/repository/mediaItemRepository.ts
@@ -3,7 +3,6 @@ import _ from 'lodash';
 
 import { TRPCError } from '@trpc/server';
 
-import { parseISO, startOfYear } from 'date-fns';
 import { Database } from '../database.js';
 import {
   EpisodeModel,
@@ -37,7 +36,6 @@ import {
   h,
   is,
   splitWhereInQuery,
-  toReleaseDateFormat,
   withDefinedPropertyFactory,
 } from '../utils.js';
 import { logger } from '../logger.js';
@@ -652,40 +650,40 @@ export const mediaItemRepository = {
           mediaItemModelToMediaItemResponse(mediaItemById[episode.tvShowId])
         ),
         episode: episodeResponseSchema.parse(episode),
-        releaseDate: parseISO(episode.releaseDate!).toISOString(),
+        releaseDate: new Date(episode.releaseDate!).toISOString(),
       })),
       ...mediaItemReleases.map((mediaItem) => ({
         mediaItem: mediaItemResponseSchema.parse(
           mediaItemModelToMediaItemResponse(mediaItem)
         ),
-        releaseDate: parseISO(mediaItem.releaseDate!).toISOString(),
+        releaseDate: new Date(mediaItem.releaseDate!).toISOString(),
       })),
       ...digitalReleases.map((mediaItem) => ({
         mediaItem: mediaItemResponseSchema.parse(
           mediaItemModelToMediaItemResponse(mediaItem)
         ),
-        releaseDate: parseISO(mediaItem.digitalReleaseDate!).toISOString(),
+        releaseDate: new Date(mediaItem.digitalReleaseDate!).toISOString(),
         releaseType: 'digital',
       })),
       ...theatricalReleases.map((mediaItem) => ({
         mediaItem: mediaItemResponseSchema.parse(
           mediaItemModelToMediaItemResponse(mediaItem)
         ),
-        releaseDate: parseISO(mediaItem.theatricalReleaseDate!).toISOString(),
+        releaseDate: new Date(mediaItem.theatricalReleaseDate!).toISOString(),
         releaseType: 'theatrical',
       })),
       ...physicalReleases.map((mediaItem) => ({
         mediaItem: mediaItemResponseSchema.parse(
           mediaItemModelToMediaItemResponse(mediaItem)
         ),
-        releaseDate: parseISO(mediaItem.physicalReleaseDate!).toISOString(),
+        releaseDate: new Date(mediaItem.physicalReleaseDate!).toISOString(),
         releaseType: 'physical',
       })),
       ...tvReleases.map((mediaItem) => ({
         mediaItem: mediaItemResponseSchema.parse(
           mediaItemModelToMediaItemResponse(mediaItem)
         ),
-        releaseDate: parseISO(mediaItem.tvReleaseDate!).toISOString(),
+        releaseDate: new Date(mediaItem.tvReleaseDate!).toISOString(),
         releaseType: 'tv',
       })),
     ])
@@ -772,7 +770,7 @@ export const mediaItemRepository = {
     );
 
     const knex = args?.trx ? args.trx : Database.knex;
-    const currentDateString = toReleaseDateFormat(new Date());
+    const currentDateString = new Date().toISOString();
 
     // Upcoming episode
     await knex('mediaItem')
@@ -919,7 +917,7 @@ const _getMediaItemsWithUserProperties = async (args: {
 }) => {
   const { trx, mediaItemIds, userId, episodeIds, seasonIds } = args;
 
-  const currentDateString = toReleaseDateFormat(new Date());
+  const currentDateString = new Date().toISOString();
 
   const uniqMediaItemIds = _.uniq(mediaItemIds);
   const uniqEpisodeIds = _.uniq(episodeIds || []);

--- a/src/repository/seenEpisodesCountRepository.ts
+++ b/src/repository/seenEpisodesCountRepository.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 import _ from 'lodash';
 
-import { h, toReleaseDateFormat } from '../utils.js';
+import { h } from '../utils.js';
 import { logger } from '../logger.js';
 
 export const seenEpisodesCountRepository = {
@@ -47,7 +47,7 @@ export const seenEpisodesCountRepository = {
       .where('isSpecialEpisode', false)
       .whereNotNull('releaseDate')
       .whereNot('releaseDate', '')
-      .where('releaseDate', '<=', toReleaseDateFormat(new Date()));
+      .where('releaseDate', '<=', new Date().toISOString());
 
     const seenEpisodesCounts = _(seenHistory)
       .uniqBy((item) => [item.userId, item.episodeId].toString())

--- a/src/routers/calendarRouter.ts
+++ b/src/routers/calendarRouter.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { mediaTypeSchema } from '../entity/mediaItemModel.js';
 import { mediaItemRepository } from '../repository/mediaItemRepository.js';
 import { protectedProcedure, router } from '../router.js';
-import { addMonths, parseISO, subMonths } from 'date-fns';
+import { addMonths, subMonths } from 'date-fns';
 import { SHA256, formatEpisodeNumber } from '../utils.js';
 import { iCalBuilder } from '../iCalBuilder.js';
 import { rssBuilder } from '../rssBuilder.js';
@@ -52,7 +52,7 @@ export const calendarRouter = router({
           title: item.episode
             ? `${item.mediaItem.title} ${formatEpisodeNumber(item.episode)}`
             : item.mediaItem.title,
-          pubDate: parseISO(item.releaseDate),
+          pubDate: new Date(item.releaseDate),
           guid: SHA256(
             `${item.mediaItem.id}${item.episode?.id}${item.releaseType}`
           ),
@@ -76,7 +76,7 @@ export const calendarRouter = router({
           uid: SHA256(
             `${item.mediaItem.id}${item.episode?.id}${item.releaseType}`
           ),
-          start: parseISO(item.releaseDate),
+          start: new Date(item.releaseDate),
           allDay: true,
           summary: item.episode
             ? `${item.mediaItem.title} ${formatEpisodeNumber(item.episode)}`

--- a/src/routers/listRouter.ts
+++ b/src/routers/listRouter.ts
@@ -4,7 +4,6 @@ import { TRPCError } from '@trpc/server';
 
 import { listRepository } from '../repository/listRepository.js';
 import { protectedProcedure, router } from '../router.js';
-import { parseISO } from 'date-fns';
 import { itemTypeSchema } from '../entity/mediaItemModel.js';
 import { rssBuilder } from '../rssBuilder.js';
 import { getConfiguration } from '../repository/configurationRepository.js';
@@ -225,7 +224,7 @@ export const listRouter = router({
             guid: item.id.toString(),
             pubDate:
               typeof item.mediaItem.releaseDate === 'string'
-                ? parseISO(item.mediaItem.releaseDate)
+                ? new Date(item.mediaItem.releaseDate)
                 : undefined,
             enclosure:
               item.mediaItem.poster && configuration.publicAddress

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,10 +25,6 @@ export const splitDeleteWhereInQuery = async <T, U>(
   return _.sum(await Promise.all(_.chunk(data, 500).map((chunk) => fn(chunk))));
 };
 
-export const toReleaseDateFormat = (date: Date) => {
-  return subMinutes(date, date.getTimezoneOffset()).toISOString();
-};
-
 export const generateExternalUrl = (mediaItem: MediaItemModel) => {
   if (mediaItem.mediaType === 'tv' || mediaItem.mediaType === 'movie') {
     if (mediaItem.imdbId) {
@@ -146,4 +142,18 @@ export const dumpFetchResponse = async (
       .join('\n')}`,
     `Response: ${await response.text()}`,
   ].join('\n\n');
+};
+
+export const tryParseDate = (dateStr?: string | null) => {
+  if (!dateStr) {
+    return;
+  }
+
+  const res = new Date(dateStr);
+
+  if (isNaN(res.getTime())) {
+    return;
+  }
+
+  return res;
 };


### PR DESCRIPTION
Most provides, including TMDB does not provide release time, only date, without any time zone information. Until now, those dates ware converted to MediaTracker local time zone, for example `2024-05-16` would always be `2024-05-16 00:00:00` in user local time.

With introduction of more precise release time from TvMaze, this became a problem. Dates like, `2024-05-16` are stored in database in this format, and converted to ISO later.

This pull requests converts all stored release dates to ISO format. Dates without time, will become a midnight in UTC time, not user local time.