### PR TITLE
store runtime in milliseconds

### DIFF
--- a/src/metadata/provider/TVmaze.ts
+++ b/src/metadata/provider/TVmaze.ts
@@ -62,7 +62,7 @@ export const TVmaze = metadataProviderFactory({
       url: data.officialSite,
       network: data.network?.name,
       externalPosterUrl: data.image?.medium,
-      runtime: data.averageRuntime,
+      runtime: (data.averageRuntime || 0) * 60 * 1000 || null,
       seasons: data._embedded.seasons.map((season) => ({
         isSpecialSeason: season.number === 0,
         seasonNumber: season.number,
@@ -79,7 +79,7 @@ export const TVmaze = metadataProviderFactory({
             seasonNumber: episode.season,
             releaseDate: tryParseISODate(episode.airstamp)?.toISOString(),
             isSpecialEpisode: episode.type === 'insignificant_special',
-            runtime: episode.runtime,
+            runtime: (episode.runtime || 0) * 60 * 1000 || null,
           })),
       })),
     };

--- a/src/metadata/provider/audible.ts
+++ b/src/metadata/provider/audible.ts
@@ -121,7 +121,7 @@ const mapItemResponse = (
     externalPosterUrl: item.product_images?.[2400],
     language: item.language,
     releaseDate: tryParseISODate(item.release_date)?.toISOString(),
-    runtime: item.runtime_length_min,
+    runtime: (item.runtime_length_min || 0) * 60 * 1000 || null,
     overview: item.merchandising_summary,
   };
 };

--- a/src/metadata/provider/tmdbMovie.ts
+++ b/src/metadata/provider/tmdbMovie.ts
@@ -299,7 +299,7 @@ const movieDetailsToMediaItemMetadata = async (
     ...mapMovie(movie),
     genres: movie.genres?.map((genre) => genre.name) || null,
     imdbId: movie.imdb_id || null,
-    runtime: movie.runtime || null,
+    runtime: (movie.runtime || 0) * 60 * 1000 || null,
     status: movie.status || null,
     url: movie.homepage || null,
     theatricalReleaseDate: tryParseISODate(theatricalReleaseDate),

--- a/src/metadata/provider/tmdbTv.ts
+++ b/src/metadata/provider/tmdbTv.ts
@@ -94,7 +94,7 @@ export const TmdbTv = metadataProviderFactory({
       genres: tvShow.genres?.map((genre) => genre.name) || null,
       imdbId: tvShow.external_ids?.imdb_id || null,
       tvdbId: tvShow.external_ids?.tvdb_id || null,
-      runtime: tvShow.episode_run_time?.at(0) || null,
+      runtime: (tvShow.episode_run_time?.at(0) || 0) * 60 * 1000 || null,
       seasons: seasons || null,
       status: tvShow.status || null,
       url: tvShow.homepage || null,
@@ -319,7 +319,7 @@ const getSeasonsDetails = async (args: {
         seasonFinale: episode.episode_type === 'finale',
         midSeasonFinale: episode.episode_type === 'mid_season',
         tmdbId: episode.id,
-        runtime: episode.runtime || null,
+        runtime: (episode.runtime || 0) * 60 * 1000 || null,
       })),
     };
   });

--- a/src/migrations/20240620000000_convertRuntimeToMiliseconds.ts
+++ b/src/migrations/20240620000000_convertRuntimeToMiliseconds.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex('mediaItem')
+    .whereNotNull('runtime')
+    .update('runtime', knex.raw('runtime * 60 * 1000'));
+
+  await knex('episode')
+    .whereNotNull('runtime')
+    .update('runtime', knex.raw('runtime * 60 * 1000'));
+}
+
+export async function down(knex: Knex): Promise<void> {}


### PR DESCRIPTION
Runtime is stored in minutes, as returned from TMDB and Audible. This is used for `duration` in seen entries, where `duration` is stored in milliseconds. Lets be consistent and use milliseconds everywhere.