### PR TITLE
Add progress/by-audible-id/:audibleId route and modify token middleware to allow Authorization: Bearer

### DIFF
--- a/server/src/controllers/progress.ts
+++ b/server/src/controllers/progress.ts
@@ -290,7 +290,13 @@ const addItem = async (args: Progress) => {
     });
   }
 
-  if (args.progress === 1 && args.episodeId == undefined) {
+  if (args.progress < 1) {
+    await listItemRepository.addItem({
+      userId: args.userId,
+      mediaItemId: args.mediaItemId,
+      watchlist: true,
+    });
+  } else if (args.progress === 1 && args.episodeId == undefined) {
     await listItemRepository.removeItem({
       userId: args.userId,
       mediaItemId: args.mediaItemId,

--- a/server/src/controllers/progress.ts
+++ b/server/src/controllers/progress.ts
@@ -181,7 +181,10 @@ export class ProgressController {
       return;
     }
 
-    const mediaItem = await mediaItemRepository.findByAudibleId(audibleId);
+    const mediaItem = await findMediaItemByExternalId({
+      id: { audibleId },
+      mediaType: 'audiobook',
+    });
 
     if (!mediaItem) {
       res.status(404).json({ message: 'Audiobook not found' });

--- a/server/src/controllers/progress.ts
+++ b/server/src/controllers/progress.ts
@@ -168,7 +168,7 @@ export class ProgressController {
     // Debug logging
     logger.debug(`Received request for audibleId: ${audibleId}`);
     logger.debug(`Request body: ${JSON.stringify(req.body)}`);
-    logger.debug(`Progress value: ${progress}, type: ${typeof progress}`);
+    logger.debug(`Progress value: ${progress}`);
 
     // Check if progress is undefined or not a number
     if (progress === undefined || isNaN(progress)) {
@@ -176,10 +176,7 @@ export class ProgressController {
       return;
     }
 
-    // Convert progress to a number if it's a string
-    const progressNumber = Number(progress);
-
-    if (progressNumber < 0 || progressNumber > 1) {
+    if (progress < 0 || progress > 1) {
       res.status(400).json({ message: 'Progress should be between 0 and 1' });
       return;
     }
@@ -203,7 +200,7 @@ export class ProgressController {
         date: Date.now(),
         duration,
         mediaItemId: mediaItem.id,
-        progress: progressNumber,
+        progress,
         device,
       });
       res.status(200).json({ message: 'Progress updated successfully' });

--- a/server/src/controllers/progress.ts
+++ b/server/src/controllers/progress.ts
@@ -6,12 +6,14 @@ import { mediaItemRepository } from 'src/repository/mediaItem';
 import { seenRepository } from 'src/repository/seen';
 import { listItemRepository } from 'src/repository/listItemRepository';
 import { MediaType } from 'src/entity/mediaItem';
-import { findMediaItemOrEpisodeByExternalId } from 'src/metadata/findByExternalId';
+import {
+  findMediaItemByExternalId,
+  findMediaItemOrEpisodeByExternalId,
+} from 'src/metadata/findByExternalId';
 import { logger } from 'src/logger';
 import { Progress } from 'src/entity/progress';
 import { Database } from 'src/dbconfig';
 import { Seen } from 'src/entity/seen';
-
 /**
  * @openapi_tags Progress
  */

--- a/server/src/controllers/progress.ts
+++ b/server/src/controllers/progress.ts
@@ -165,7 +165,21 @@ export class ProgressController {
     const { audibleId } = req.params;
     const { progress, action, duration, device } = req.body;
 
-    if (progress === undefined || progress < 0 || progress > 1) {
+    // Debug logging
+    logger.debug(`Received request for audibleId: ${audibleId}`);
+    logger.debug(`Request body: ${JSON.stringify(req.body)}`);
+    logger.debug(`Progress value: ${progress}, type: ${typeof progress}`);
+
+    // Check if progress is undefined or not a number
+    if (progress === undefined || isNaN(progress)) {
+      res.status(400).json({ message: 'Invalid or missing progress value' });
+      return;
+    }
+
+    // Convert progress to a number if it's a string
+    const progressNumber = Number(progress);
+
+    if (progressNumber < 0 || progressNumber > 1) {
       res.status(400).json({ message: 'Progress should be between 0 and 1' });
       return;
     }
@@ -183,18 +197,18 @@ export class ProgressController {
     }
 
     try {
-      await this.addItem({
+      await addItem({
         userId,
         action,
         date: Date.now(),
         duration,
         mediaItemId: mediaItem.id,
-        progress,  // Ensure this is being passed correctly
+        progress: progressNumber,
         device,
       });
       res.status(200).json({ message: 'Progress updated successfully' });
     } catch (error) {
-      console.error('Error updating progress:', error);
+      logger.error('Error updating progress:', error);
       res.status(500).json({ message: 'Error updating progress', error: error.message });
     }
   });

--- a/server/src/controllers/progress.ts
+++ b/server/src/controllers/progress.ts
@@ -146,6 +146,60 @@ export class ProgressController {
   });
 
   /**
+   * @openapi_operationId addByAudibleId
+   */
+   addByAudibleId = createExpressRoute<{
+    method: 'put';
+    path: '/api/progress/by-audible-id/:audibleId';
+    pathParams: {
+      audibleId: string;
+    };
+    requestBody: {
+      action?: 'paused' | 'playing';
+      progress?: number;
+      duration?: number;
+      device?: string;
+    };
+  }>(async (req, res) => {
+    const userId = Number(req.user);
+    const { audibleId } = req.params;
+    const { action, progress, duration, device } = req.body;
+
+      if (progress != undefined && (progress < 0 || progress > 1)) {
+        res.status(400);
+        res.send('Progress should be between 0 and 1');
+        return;
+      }
+
+    const mediaItem = await mediaItemRepository.findByAudibleId(audibleId);
+
+    if (!mediaItem) {
+      res.status(404);
+      res.send('Audiobook not found');
+      return;
+    }
+
+    if (mediaItem.mediaType !== 'audiobook') {
+      res.status(400);
+      res.send('The provided Audible ID is not associated with an audiobook');
+      return;
+    }
+
+    await addItem({
+      userId: userId,
+      action: action,
+      date: Date.now(),
+      duration: duration,
+      mediaItemId: mediaItem.id,
+      progress: progress,
+      device: device,
+    });
+
+    res.send();
+  });
+    
+    
+  /**
    * @openapi_operationId deleteById
    */
   deleteById = createExpressRoute<{

--- a/server/src/generated/routes/routes.ts
+++ b/server/src/generated/routes/routes.ts
@@ -719,6 +719,8 @@ router.put(
           properties: {
             imdbId: { type: ['string', 'null'] },
             tmdbId: { type: ['number', 'null'] },
+            audibleId: { type: ['string', 'null'] },
+            igdbId: { type: ['number', 'null'] },
           },
         },
         seasonNumber: { type: ['number', 'null'] },

--- a/server/src/metadata/findByExternalId.ts
+++ b/server/src/metadata/findByExternalId.ts
@@ -66,6 +66,8 @@ export const findMediaItemOrEpisodeByExternalId = async (args: {
   id: {
     imdbId?: string;
     tmdbId?: number;
+    audibleId?: string;
+    igdbId?: number;
   };
   seasonNumber?: number;
   episodeNumber?: number;
@@ -81,7 +83,7 @@ export const findMediaItemOrEpisodeByExternalId = async (args: {
     };
   }
 
-  if (!id.imdbId && !id.tmdbId) {
+  if (!id.imdbId && !id.tmdbId && !id.audibleId && !id.igdbId) {
     return {
       error: 'At least one external id is required',
     };

--- a/server/src/middlewares/token.ts
+++ b/server/src/middlewares/token.ts
@@ -4,9 +4,23 @@ import { accessTokenRepository } from 'src/repository/accessToken';
 
 export class AccessTokenMiddleware {
   static async authorize(req: Request, res: Response, next: NextFunction) {
-    const token =
-      req.header('Access-Token') ||
-      (typeof req.query.token === 'string' && req.query.token);
+    let token: string | undefined;
+
+    // Check for token in Authorization header
+    const authHeader = req.header('Authorization');
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+      token = authHeader.substring(7); // Remove 'Bearer ' prefix
+    }
+
+    // If not found in Authorization header, check Access-Token header
+    if (!token) {
+      token = req.header('Access-Token');
+    }
+
+    // If still not found, check query parameter
+    if (!token && typeof req.query.token === 'string') {
+      token = req.query.token;
+    }
 
     if (!token) {
       next();

--- a/server/src/repository/mediaItem.ts
+++ b/server/src/repository/mediaItem.ts
@@ -468,6 +468,17 @@ class MediaItemRepository extends repository<MediaItemBase>({
     }
   }
 
+  public async findByAudibleId(audibleId: string): Promise<MediaItemBase | undefined> {
+    const res = await Database.knex<MediaItemBase>(this.tableName)
+      .where({ audibleId: audibleId })
+      .first();
+
+    if (res) {
+      return this.deserialize(res);
+    }
+  }
+    
+    
   public async findByTitle(params: {
     mediaType: MediaType;
     title: string;

--- a/server/src/repository/mediaItem.ts
+++ b/server/src/repository/mediaItem.ts
@@ -467,17 +467,6 @@ class MediaItemRepository extends repository<MediaItemBase>({
       return this.deserialize(res);
     }
   }
-
-  public async findByAudibleId(audibleId: string): Promise<MediaItemBase | undefined> {
-    const res = await Database.knex<MediaItemBase>(this.tableName)
-      .where({ audibleId: audibleId })
-      .first();
-
-    if (res) {
-      return this.deserialize(res);
-    }
-  }
-    
     
   public async findByTitle(params: {
     mediaType: MediaType;


### PR DESCRIPTION
Based on [issue 637](https://github.com/bonukai/MediaTracker/issues/637) this adds:

- A route to allow adding progress to an item via just its audibleId (progress/by-audible-id/:audibleId). This will allow a hook integration with AudioBookShelf so that as content is played in that system, it can automatically update MediaTracker without having to know the itemId in MediaTracker.

- A method to the MediaItemRepository to find an item by its audibleId (findByAudibleId)

- A change to the token middleware so that the token can be passed in one of three ways (checked in this order):
    1. in the header, via Authorization: Bearer <TOKEN>  as is commonly used in JWT
    2. in the header, via Access-Token: <TOKEN> as is done in the current implementation
    3. as a query parameter ?token=<TOKEN> as is done in the current implementation

Hope these changes can help add even more scrobbling to MediaTracker and extend its functionality for Audiobooks!