### PR TITLE
WIP updates to allow postgres database connectivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/cookie-parser": "^1.4.7",
         "@types/express": "^4.17.21",
         "@types/lodash": "^4.17.1",
+        "@types/pg": "^8.11.10",
         "esbuild": "^0.21.1",
         "glob": "^10.3.12",
         "openapi-types": "^12.1.3",
@@ -1882,6 +1883,74 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true
+    },
+    "node_modules/@types/pg": {
+      "version": "8.11.10",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.10.tgz",
+      "integrity": "sha512-LczQUW4dbOQzsH2RQ5qoeJ6qJPdrcM/DcMLoqWQkMLMsq83J5lAX3LXjdkWdpscFy67JSOWDnh7Ny/sPFykmkg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -4065,6 +4134,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4327,6 +4402,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
@@ -4499,6 +4583,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true
     },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
@@ -6765,6 +6855,61 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true
     },
+    "@types/pg": {
+      "version": "8.11.10",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.10.tgz",
+      "integrity": "sha512-LczQUW4dbOQzsH2RQ5qoeJ6qJPdrcM/DcMLoqWQkMLMsq83J5lAX3LXjdkWdpscFy67JSOWDnh7Ny/sPFykmkg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      },
+      "dependencies": {
+        "pg-types": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+          "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+          "dev": true,
+          "requires": {
+            "pg-int8": "1.0.1",
+            "pg-numeric": "1.0.2",
+            "postgres-array": "~3.0.1",
+            "postgres-bytea": "~3.0.0",
+            "postgres-date": "~2.1.0",
+            "postgres-interval": "^3.0.0",
+            "postgres-range": "^1.1.1"
+          }
+        },
+        "postgres-array": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+          "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+          "dev": true
+        },
+        "postgres-bytea": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+          "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+          "dev": true,
+          "requires": {
+            "obuf": "~1.1.2"
+          }
+        },
+        "postgres-date": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+          "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+          "dev": true
+        },
+        "postgres-interval": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+          "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+          "dev": true
+        }
+      }
+    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -8349,6 +8494,12 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
     },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8541,6 +8692,12 @@
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
+    "pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true
+    },
     "pg-pool": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
@@ -8666,6 +8823,12 @@
       "requires": {
         "xtend": "^4.0.0"
       }
+    },
+    "postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true
     },
     "prebuild-install": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/cookie-parser": "^1.4.7",
     "@types/express": "^4.17.21",
     "@types/lodash": "^4.17.1",
+    "@types/pg": "^8.11.10",
     "esbuild": "^0.21.1",
     "glob": "^10.3.12",
     "openapi-types": "^12.1.3",

--- a/src/database.ts
+++ b/src/database.ts
@@ -17,10 +17,6 @@ const databaseConfigSchema = z.discriminatedUnion('client', [
     client: z.literal('pg'),
     connectionString: z.string(),
   }),
-  z.object({
-    client: z.literal('mysql'),
-    connectionString: z.string(),
-  }),
 ]);
 
 export type DatabaseConfig = z.infer<typeof databaseConfigSchema>;

--- a/src/database.ts
+++ b/src/database.ts
@@ -15,7 +15,7 @@ const databaseConfigSchema = z.discriminatedUnion('client', [
   z.object({
     client: z.literal('pg'),
     connectionString: z.string(),
-  }),
+}),
   z.object({
     client: z.literal('mysql'),
     connectionString: z.string(),
@@ -62,9 +62,34 @@ export class Database {
           : databaseConfiguration.connectionString,
 
       useNullAsDefault: true,
+      // Conditionally add postProcessResponse only for PostgreSQL to deal with numerics returned as string
+      ...(databaseConfiguration.client === 'pg' && {
+        postProcessResponse: (result) => {
+          if (Array.isArray(result)) {
+            return result.map((row) => this.#convertNumericColumns(row));
+          } else if (result && typeof result === 'object') {
+            return this.#convertNumericColumns(result);
+          }
+          return result; // Return as is for other cases
+        },
+      }),
     });
   }
 
+  // Helper function to safely convert numeric column values from strings back to numbers.
+  // Javascript doesnt have a 64bit int or decimal, so values all convert to floats.
+  // This potentially returns some incorrect numbers, but ... it should be OK for tmdbRatings.
+  static #convertNumericColumns(row: Record<string, any>): Record<string, any> {
+    const convertedRow = { ...row };
+    for (const key in row) {
+      const value = row[key];
+      if (typeof value === 'string' && !Number.isNaN(Number(value))) {
+        convertedRow[key] = Number(value);
+      }
+    }
+    return convertedRow;
+  }
+  
   static async runMigrations(verbose = true): Promise<void> {
     if (verbose) {
       logger.info(`running migrations`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import { Database, DatabaseConfig } from './database.js';
 import { startServer } from './server.js';
 import { StaticConfiguration } from './staticConfiguration.js';
 import { h } from './utils.js';
-import { logger } from './logger.js';
 
 const inputValidator = (zodSchema: ZodSchema) => {
   return (value: string) => {
@@ -52,18 +51,21 @@ program
     new Option('--db-client <string>', 'database client')
       .choices(databaseClientSchema.options)
       .default('SQLite')
+      .makeOptionMandatory()
   )
   .addOption(
     new Option('--db-filepath <path>', 'SQLite database path')
-    .conflicts('dbConnectiongString')
-    .implies({dbClient: 'SQLite', dbConnectionString: undefined})
-    .default(path.resolve(os.homedir(), '.mediatracker', 'data.db'))
+      .conflicts('dbConnectionString')
+      .implies({ dbClient: 'SQLite', dbConnectionString: undefined })
+      .default(path.resolve(os.homedir(), '.mediatracker', 'data.db'))
   )
   .addOption(
-    new Option('--db-connection-string <string>', 'PostgreSQL database connection string')
-    .conflicts('dbFilepath')
-    //if dbclient not specifed on command line, but connection-string is, default to postgres
-    .implies({dbClient: 'PostgreSQL', dbFilepath: undefined})
+    new Option(
+      '--db-connection-string <string>',
+      'PostgreSQL database connection string'
+    )
+      .conflicts('dbFilepath')
+      .implies({ dbFilepath: undefined })
   )
   .addOption(
     new Option('--logs-dir <path>', 'logs directory')
@@ -75,30 +77,7 @@ program
       .default(path.resolve(os.homedir(), '.mediatracker', 'img'))
       .argParser(createDirectories)
   )
-  .addOption(new Option('--demo', 'demo mode'))
-  .action((options) => {
-
-    const { dbClient, dbFilepath, dbConnectionString } = options;
-
-    // Apply conditional logic for defaults and validation
-    // If a user supplies just a connection string on the command line, dbclient would default to sqlite
-    if (dbClient === 'SQLite' && dbConnectionString) {
-      logger.warn('--db-connection-string must not be set when --db-client is SQLite');
-      opts.dbConnectionString = undefined;
-    } else if (dbClient === 'PostgreSQL' && dbFilepath) {
-      //since dbFilePath has a default value, need to unset it again when dbClient is PostgreSQL
-      logger.warn('--db-filepath must not be set when --db-client is PostgreSQL');
-      opts.dbFilepath = undefined;
-    } 
-    
-    // Validate correct value combinations
-    if (dbClient === 'SQLite' && !dbFilepath) {
-      throw new Error('--db-filepath must be set when --db-client is SQLite');
-    } else if (dbClient === 'PostgreSQL' && !dbConnectionString) {
-      throw new Error('--db-connection-string must be set when --db-client is PostgreSQL');
-    }
-  }
-);
+  .addOption(new Option('--demo', 'demo mode'));
 
 const commands: Command[] = [];
 

--- a/src/migrations/20241129000000_justWatchProvider2.ts
+++ b/src/migrations/20241129000000_justWatchProvider2.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+
+  await knex.schema.dropTable('justWatchAvailability');
+  await knex.schema.dropTable('justWatchProvider');
+
+  await knex.schema.createTable('justWatchProvider', (table) => {
+    table.increments('id').primary();
+    table.string('externalLogoUrl');
+    table.string('name');
+    table.string('logo');
+
+    table.index(['logo']);
+  });
+
+  await knex.schema.createTable('justWatchAvailability', (table) => {
+    table.increments('id').primary();
+    table.integer('providerId').references('id').inTable('justWatchProvider');
+    table.integer('mediaItemId').references('id').inTable('mediaItem');
+    table.string('type');
+    table.string('country');
+    table.integer('displayPriority');
+
+    table.index(['mediaItemId']);
+    table.index(['mediaItemId', 'providerId']);
+  });
+
+}
+
+export async function down(knex: Knex): Promise<void> {}

--- a/src/migrations/20241129000000_justWatchProviderAutoIncrementId.ts
+++ b/src/migrations/20241129000000_justWatchProviderAutoIncrementId.ts
@@ -1,6 +1,8 @@
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
+  const justWatchAvailabilityData = await knex('justWatchAvailability');
+  const justWatchProviderData = await knex('justWatchProvider');
 
   await knex.schema.dropTable('justWatchAvailability');
   await knex.schema.dropTable('justWatchProvider');
@@ -26,6 +28,13 @@ export async function up(knex: Knex): Promise<void> {
     table.index(['mediaItemId', 'providerId']);
   });
 
+  await knex.batchInsert('justWatchProvider', justWatchProviderData, 100);
+
+  await knex.batchInsert(
+    'justWatchAvailability',
+    justWatchAvailabilityData,
+    100
+  );
 }
 
 export async function down(knex: Knex): Promise<void> {}

--- a/src/repository/mediaItemRepository.ts
+++ b/src/repository/mediaItemRepository.ts
@@ -812,6 +812,7 @@ export const mediaItemRepository = {
                 'upcomingEpisode.seasonAndEpisodeNumber'
               )
           )
+          .limit(1)
       );
 
     // Last aired episode
@@ -850,6 +851,7 @@ export const mediaItemRepository = {
                 'lastAiredEpisode.seasonAndEpisodeNumber'
               )
           )
+          .limit(1)
       );
 
     // Number of aired episodes

--- a/src/repository/mediaItemRepository.ts
+++ b/src/repository/mediaItemRepository.ts
@@ -1043,10 +1043,10 @@ const _getMediaItemsWithUserProperties = async (args: {
 
   const lastSeenMediaItem = await splitWhereInQuery(uniqMediaItemIds, (chunk) =>
     trx('seen')
-      .select('date', 'mediaItemId')
+      .select('mediaItemId')
+      .max({ date: 'date' })
       .where('userId', userId)
       .whereIn('mediaItemId', chunk)
-      .max({ date: 'date' })
       .groupBy('mediaItemId')
   );
 

--- a/src/repository/mediaItemRepository.ts
+++ b/src/repository/mediaItemRepository.ts
@@ -725,7 +725,11 @@ export const mediaItemRepository = {
         )
         .whereNull('userRating.rating');
 
-      const countRes = await query.clone().count({ count: '*' });
+      const countRes = await query
+        .clone() // Copy the query
+        .clearSelect() // Then clear selected columns because it had mediaItem.*
+        .count({ count: '*' }); // Now count the rows
+
       const items: MediaItemModel[] = await query
         .clone()
         .orderBy('seen.date', 'desc')


### PR DESCRIPTION
I've made a few updates in the WIP branch which allow you to at least start MediaTracker and not generate a ton of db query complaints while using a postgres database. It should now also be a bit easier to allow connecting to mysql/mariadb, sql server or various others.

Commit 9244da9: fix option parsing to allow use of postgresql
Primarily, the application would not start when trying to configure postgres connection due to the db-filepath option being defaulted to <a value>. since db-connection-string and db-file-path are mutually exclusive and the program exits with error, this locked out anything except sqlite. Option parsing then didn't allow a value check to confirm which value of dbclient could be used with connection-string or filepath, so added in a .action() to validate. The validation throw new Error() should not actually get hit at any point, it's just there for safety.

Commit e47eeec: fix the error when picking the max seen date per mediaitem
This error was caused by trying to both select the date column and do a group-by on it, so a simple fix.

Commit 84f395d: fix issue with numeric values being returned as strings
Per the commit comment - This broke mediaItemModelSchema because mediaItem.tmdbRating is defined as a decimal(8,2) value, but the database query returned a string due to no implicit type conversion from decimal to float in typescript.
When the data query returned, and tried to map the data into rows of mediaItemModelSchema, tmdbRating errored because it would be a string value ie: "7.6" instead of just: 7.6. This is a base JS limitation of not having a suitable data type conversion for _accurate_ decimal/numeric values (>32bit), only floats. Choices are to either: 
- change the data type in the database to float, int or string then deal with all conversions manually (ugh)
- make tmdbRating a string in the data model and database (a bit icky and potential future issue)
- accept that some accuracy might be lost by returning round(7.59999990463256836,2) instead of 7.6
For tv and movie ratings, I think the minor accuracy variation is fine. If MediaTracker needs to store currency or high decimal accuracy values at some point, then perhaps a rethink here.

Commit ad17031: remove sortQuery when doing a simple count(*)
First part pretty straightforward - don't need to sort results to count em.
Second part is a re-write of the query to create a subquery for unseenEpisodesCount. sqlite can refer to dynamic column aliases in the where of the same select level, but postgres (and most other db's) cannot. generally, you can only use an alias in the result set, not the where, group-by, order-by or having at the same query level.

Commit 2bcba94: remove select * when doing a count(*)
Cloning the previous query to do a count(*) meant including select mediaItem.*, so all columns (or at least the pk) from mediaItem would have to be included in a group-by as well. Easier to just clear the selected columns and return only the count when that's all that's needed.
