### PR TITLE
optimize list items seen filter

### DIFF
--- a/src/@types/knex.d.ts
+++ b/src/@types/knex.d.ts
@@ -21,6 +21,7 @@ import { SeenEpisodesCountModel } from '../entity/seenEpisodesCountModel.ts';
 import { ServerInternalSettingsModel } from '../entity/serverSettingsModel.ts';
 import { MessageModel } from '../entity/messageModel.ts';
 import { HomeSectionModel } from '../entity/homeSectionModel.ts';
+import { HasBeenSeenModel } from '../entity/hasBeenSeenModel.ts';
 
 declare module 'knex/types/tables.js' {
   interface Tables {
@@ -43,5 +44,6 @@ declare module 'knex/types/tables.js' {
     seenEpisodesCount: SeenEpisodesCountModel;
     message: MessageModel;
     homeSection: HomeSectionModel;
+    hasBeenSeen: HasBeenSeenModel;
   }
 }

--- a/src/entity/hasBeenSeenModel.ts
+++ b/src/entity/hasBeenSeenModel.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const hasBeenSeenModelSchema = z.object({
+  userId: z.number(),
+  mediaItemId: z.number(),
+});
+
+export type HasBeenSeenModel = z.infer<typeof hasBeenSeenModelSchema>;

--- a/src/migrations/20241208000000_hasBeenSeen.ts
+++ b/src/migrations/20241208000000_hasBeenSeen.ts
@@ -1,0 +1,43 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('hasBeenSeen', (table) => {
+    table.integer('userId').references('id').inTable('user').notNullable();
+    table
+      .integer('mediaItemId')
+      .references('id')
+      .inTable('mediaItem')
+      .notNullable();
+
+    table.primary(['userId', 'mediaItemId']);
+  });
+
+  await knex
+    .insert((db: Knex.QueryBuilder) =>
+      db
+        .from('seen')
+        .leftJoin('mediaItem', 'mediaItem.id', 'seen.mediaItemId')
+        .where('mediaType', '<>', 'tv')
+        .distinct(['userId', 'mediaItemId'])
+    )
+    .into('hasBeenSeen');
+
+  await knex
+    .insert((db: Knex.QueryBuilder) =>
+      db
+        .from('mediaItem')
+        .where('mediaType', 'tv')
+        .leftJoin(
+          'seenEpisodesCount',
+          'mediaItem.id',
+          'seenEpisodesCount.mediaItemId'
+        )
+        .where('seenEpisodesCount', 'numberOfAiredEpisodes')
+        .select('userId', 'mediaItemId')
+    )
+    .into('hasBeenSeen');
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('hasBeenSeen');
+}

--- a/src/repository/hasBeenSeenRepository.ts
+++ b/src/repository/hasBeenSeenRepository.ts
@@ -1,0 +1,70 @@
+import { Knex } from 'knex';
+import { logger } from '../logger.js';
+import { h } from '../utils.js';
+
+export const hasBeenSeenRepository = {
+  async recalculate(args: {
+    trx: Knex.Transaction;
+    userId?: number;
+    mediaItemIds?: number[];
+  }) {
+    const { trx, userId, mediaItemIds } = args;
+
+    if (mediaItemIds && mediaItemIds.length === 0) {
+      return;
+    }
+
+    logger.debug(
+      h`recalculating hasBeenSeen ${
+        userId ? `for ${`user ${userId}`}` : ''
+      } for ${mediaItemIds ? mediaItemIds.length : 'all'} media item${
+        mediaItemIds && mediaItemIds.length > 1 ? 's' : ''
+      }`
+    );
+
+    const addUserAndMediaItemWhere = <T extends object>(
+      qb: Knex.QueryBuilder<T>
+    ) => {
+      if (mediaItemIds) {
+        if (mediaItemIds.length === 1) {
+          qb.where('mediaItemId', mediaItemIds[0]);
+        } else {
+          qb.whereIn('mediaItemId', mediaItemIds);
+        }
+      }
+
+      if (userId) {
+        qb.where('userId', userId);
+      }
+    };
+
+    await trx('hasBeenSeen').modify(addUserAndMediaItemWhere).delete();
+
+    await trx
+      .insert((db: Knex.QueryBuilder) =>
+        db
+          .from('seen')
+          .leftJoin('mediaItem', 'mediaItem.id', 'seen.mediaItemId')
+          .where('mediaType', '<>', 'tv')
+          .modify(addUserAndMediaItemWhere)
+          .distinct(['userId', 'mediaItemId'])
+      )
+      .into('hasBeenSeen');
+
+    await trx
+      .insert((db: Knex.QueryBuilder) =>
+        db
+          .from('mediaItem')
+          .where('mediaType', 'tv')
+          .leftJoin(
+            'seenEpisodesCount',
+            'mediaItem.id',
+            'seenEpisodesCount.mediaItemId'
+          )
+          .where('seenEpisodesCount', trx.ref('numberOfAiredEpisodes'))
+          .modify(addUserAndMediaItemWhere)
+          .select('userId', 'mediaItemId')
+      )
+      .into('hasBeenSeen');
+  },
+} as const;

--- a/src/repository/mediaItemRepository.ts
+++ b/src/repository/mediaItemRepository.ts
@@ -39,6 +39,7 @@ import {
   withDefinedPropertyFactory,
 } from '../utils.js';
 import { logger } from '../logger.js';
+import { hasBeenSeenRepository } from './hasBeenSeenRepository.js';
 
 export const mediaItemRepository = {
   async findByExternalId(args: {
@@ -937,6 +938,11 @@ export const mediaItemRepository = {
           .whereNotNull('releaseDate')
           .where('episode.tvShowId', trx.ref('mediaItem.id'))
       );
+
+    await hasBeenSeenRepository.recalculate({
+      trx,
+      mediaItemIds: args?.mediaItemIds,
+    });
   },
 } as const;
 

--- a/src/repository/seenRepository.ts
+++ b/src/repository/seenRepository.ts
@@ -4,6 +4,7 @@ import { Database } from '../database.js';
 import { is, splitDeleteWhereInQuery, splitWhereInQuery } from '../utils.js';
 import { mediaItemRepository } from './mediaItemRepository.js';
 import { seenEpisodesCountRepository } from './seenEpisodesCountRepository.js';
+import { hasBeenSeenRepository } from './hasBeenSeenRepository.js';
 
 export const seenRepository = {
   async add(args: {
@@ -49,6 +50,12 @@ export const seenRepository = {
         .delete();
 
       await seenEpisodesCountRepository.recalculate({
+        trx,
+        mediaItemIds: [mediaItemId],
+        userId,
+      });
+
+      await hasBeenSeenRepository.recalculate({
         trx,
         mediaItemIds: [mediaItemId],
         userId,
@@ -123,6 +130,12 @@ export const seenRepository = {
         userId,
       });
 
+      await hasBeenSeenRepository.recalculate({
+        trx,
+        mediaItemIds: [mediaItemId],
+        userId,
+      });
+
       return res;
     });
   },
@@ -152,6 +165,12 @@ export const seenRepository = {
       }
 
       await seenEpisodesCountRepository.recalculate({
+        trx,
+        mediaItemIds: [mediaItem.id],
+        userId,
+      });
+
+      await hasBeenSeenRepository.recalculate({
         trx,
         mediaItemIds: [mediaItem.id],
         userId,
@@ -191,6 +210,12 @@ export const seenRepository = {
         trx,
         userId,
         mediaItemIds: [existingSeenTransactions[0].mediaItemId],
+      });
+
+      await hasBeenSeenRepository.recalculate({
+        trx,
+        mediaItemIds: [existingSeenTransactions[0].mediaItemId],
+        userId,
       });
     });
   },


### PR DESCRIPTION
Creates a table `hasBeenSeen` with precalculated values for each user and mediaItem, tv shows in particular, as those will change when a new episode is released ("seen" tv shows is no longer "seen", when new episode is released). Filtering lists for tv shows results in complicated and expensive queries. This helper table greatly simplifies it and improves performance.