### PR TITLE
config.ts: allow to set PUBLIC_PATH via environment

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -30,7 +30,8 @@ export class Config {
     | 'production'
     | 'test';
 
-  static readonly PUBLIC_PATH = join(__dirname, '../public');
+  static readonly PUBLIC_PATH =
+    process.env.PUBLIC_PATH || join(__dirname, '../public');
 
   static readonly ASSETS_PATH =
     process.env.ASSETS_PATH || join(this.configDirectory, 'img');


### PR DESCRIPTION
i am trying to package the project for nixos, this posed more of a challenge than expected as the client requires the rest-api module which can only be built after generating data from the server.
That is why currently i've split the package into two parts which results in two artifacts which are indepentent of each other.
By overriding the PUBLIC_PATH it is possible to set the path to the generated frontend on a later stage.